### PR TITLE
switched out date and decimal converters

### DIFF
--- a/HarmonyCore/Converters/CustomDateRoutines.dbl
+++ b/HarmonyCore/Converters/CustomDateRoutines.dbl
@@ -113,3 +113,280 @@
 	
 	xreturn
 .end
+
+
+function DateTimeToDec ,d
+    in req dt		,System.DateTime
+    in req fmt		,a20
+    endparams
+    record
+        rtn		,d20
+    endrecord
+proc
+    data val,string
+    data mysize,int, %size(%atrim(fmt))
+    rtn = 0
+    if ((fmt == "YYYYMMDDHHMISSUUUUUU") .and. (mysize == 20))
+    begin
+        val = dt.ToString("yyyyMMddHHmmss")
+        if (val.Equals("00010101000000")) then
+        begin
+            val = "00000000000000000000"
+        end
+        else
+        begin
+            data milsec, int, dt.Millisecond;
+            data milSeconds, String, milsec.ToString();
+            while (milSeconds.Length < 6)
+            begin
+                milSeconds = "0" + milSeconds;
+            end
+            val = val + milSeconds;
+        end
+    end
+    if ((fmt == "YYYYMMDDHHMISS") .and. (mysize == 14))
+    begin
+        val = dt.ToString("yyyyMMddHHmmss")
+        if (val.Equals("00010101000000"))
+            val = "00000000000000"
+    end
+    if ((fmt .eq. "YYYYMMDDHHMMSS") .and. (mysize == 14))
+    begin
+        val = dt.ToString("yyyyMMddHHmmss")
+        if (val.Equals("00010101000000"))
+            val = "00000000000000"
+    end
+    if ((fmt .eq. "YYYYMMDD") .and. (mysize == 8))
+    begin
+        val = dt.ToString("yyyyMMdd")
+        if (val.Equals("00010101"))
+            val = "00000000"
+    end
+    if ((fmt .eq. "YYMMDD") .and. (mysize == 6))
+    begin
+        val = dt.ToString("yyMMdd")
+        if (val.Equals("010101"))
+            val = "000000"
+    end
+    if ((fmt .eq. "YYYYJJJ") .and. (mysize == 7))
+    begin
+        val = dt.ToString("yyyyMMdd")
+        val = val.Substring(0, 4)
+        if (dt.DayOfYear < 10) then
+            val = val + "00" + dt.DayOfYear.ToString()
+        else
+        begin
+            if (dt.DayOfYear < 100) then
+                val = val + "0" + dt.DayOfYear.ToString()
+            else
+                val = val + dt.DayOfYear.ToString()
+        end
+        if (val.Equals("0001001"))
+            val = "0000000"
+    end
+    if ((fmt .eq. "YYJJJ") .and. (mysize == 5))
+    begin
+        val = dt.ToString("yyMMdd")
+        val = val.Substring(0, 2)
+        if (dt.DayOfYear < 10) then
+            val = val + "00" + dt.DayOfYear.ToString()
+        else
+        begin
+            if (dt.DayOfYear < 100) then
+                val = val + "0" + dt.DayOfYear.ToString()
+            else
+                val = val + dt.DayOfYear.ToString()
+        end
+        if (val.Equals("01001"))
+            val = "00000"
+    end
+    if (fmt .eq. "HHMM")
+    begin
+        if (mysize .eq. 6) then
+            val = dt.ToString("HHmmss")
+        else
+            val = dt.ToString("HHmm")
+    end
+    rtn = val
+    freturn rtn
+end
+
+function DecToDateTime ,long
+    in req sdt		,d
+    in req fmt		,a14
+    endparams
+    record
+        rtn		,d14
+		
+        ticks	,long
+        yy		,int
+        mt		,int
+        dd		,int
+        jday	,double
+        hh		,int
+        mm		,int
+        ss		,int
+        ml		,int
+    endrecord
+proc
+    data val		,string
+    data valstr	,string
+    data dt		,System.Datetime
+    data format	,@System.IFormatProvider
+    data mysize,int, %size(%atrim(fmt))
+	
+    try
+    begin	
+        dt = new System.DateTime(1999, 4,12)
+        format = new System.Globalization.CultureInfo("en-US", true)
+        if ((fmt == "YYYYMMDDHHMISSUUUUUU") .and. (mysize == 20))
+        begin
+            valstr = %string(sdt,"XXXXXXXXXXXXXXXXXXXX")
+            yy = int.Parse(valstr.Substring(0,4))
+            mt = int.Parse(valstr.Substring(4,2))
+            dd = int.Parse(valstr.Substring(6,2))
+            hh = int.Parse(valstr.Substring(8,2))
+            mm = int.Parse(valstr.Substring(10,2))
+            ss = int.Parse(valstr.Substring(12,2))
+            ml = int.Parse(valstr.Substring(14,6))
+            ml = ml / 1000
+            dt = new System.DateTime(yy,mt,dd,hh,mm,ss,ml)
+        end
+        if ((fmt == "YYYYMMDDHHMISS") .and. (mysize == 14))
+        begin
+            valstr = %string(sdt,"XXXXXXXXXXXXXX")
+            yy = int.Parse(valstr.Substring(0,4))
+            mt = int.Parse(valstr.Substring(4,2))
+            dd = int.Parse(valstr.Substring(6,2))
+            hh = int.Parse(valstr.Substring(8,2))
+            mm = int.Parse(valstr.Substring(10,2))
+            ss = int.Parse(valstr.Substring(12,2))
+            dt = new System.DateTime(yy,mt,dd,hh,mm,ss)
+        end
+        if ((fmt .eq. "YYYYMMDDHHMMSS") .and. (mysize == 14))
+        begin
+            valstr = %string(sdt,"XXXXXXXXXXXXXX")
+            yy = int.Parse(valstr.Substring(0,4))
+            mt = int.Parse(valstr.Substring(4,2))
+            dd = int.Parse(valstr.Substring(6,2))
+            hh = int.Parse(valstr.Substring(8,2))
+            mm = int.Parse(valstr.Substring(10,2))
+            ss = int.Parse(valstr.Substring(12,2))
+            dt = new System.DateTime(yy,mt,dd,hh,mm,ss)
+        end
+        if ((fmt .eq. "YYYYMMDD") .and. (mysize== 8))
+        begin
+            valstr = %string(sdt,"XXXXXXXX")
+            if (valstr.Equals("00000000")) then
+            begin
+                dt = new System.DateTime()
+            end
+            else
+            begin
+                dt = System.DateTime.ParseExact(valstr,"yyyyMMdd",format)
+            end
+        end
+        if ((fmt .eq. "YYMMDD") .and. (mysize == 6))
+        begin
+            valstr = %string(sdt,"XXXXXX")
+            if (valstr.Equals("000000")) then
+            begin
+                dt = new System.DateTime()
+            end
+            else
+            begin
+                if (valstr.Length == 5)
+                    valstr = "0" + valstr
+                dt = System.DateTime.ParseExact(valstr,"yyMMdd",format)
+            end
+        end
+        if ((fmt .eq. "YYYYJJJ") .and. (mysize== 7))
+        begin
+            valstr = %string(sdt,"XXXXXXX")
+            if (valstr.Equals("0000000")) then
+            begin
+                dt = new System.DateTime()
+            end
+            else
+            begin
+                yy = int.Parse(valstr.Substring(0,4))
+                jday = double.Parse(valstr.Substring(4,3))
+                dt = new System.DateTime(yy,1,1)
+                dt = dt.AddDays(jday-1)
+            end
+        end
+        if ((fmt .eq. "YYJJJ") .and. (mysize == 5))
+        begin
+            valstr = %string(sdt,"XXXXX")
+            yy = int.Parse(valstr.Substring(0,2))
+            if (yy <= 50) then
+                yy = yy + 2000
+            else
+                yy = yy + 1900
+            jday = double.Parse(valstr.Substring(2,3))
+            dt = new System.DateTime(yy,1,1)
+            dt = dt.AddDays(jday-1)
+        end
+        if (fmt .eq. "HHMM")
+        begin
+            if (mysize .eq. 6) then
+            begin
+                valstr = %string(sdt,"XXXXXX")
+                dt = new System.DateTime()
+                hh = int.Parse(valstr.Substring(0,2))
+                mm = int.Parse(valstr.Substring(2,2))
+                ss = int.Parse(valstr.Substring(4,2))
+                dt = dt.AddHours(hh)
+                dt = dt.AddMinutes(mm)
+                dt = dt.AddSeconds(ss)
+            end
+            else
+            begin
+                valstr = %string(sdt,"XXXX")
+                dt = new System.DateTime()
+                hh = int.Parse(valstr.Substring(0,2))
+                mm = int.Parse(valstr.Substring(2,2))
+                dt = dt.AddHours(hh)
+                dt = dt.AddMinutes(mm)
+            end
+        end
+    end
+    catch(e)
+        nop
+    endtry
+	
+    ticks = dt.Ticks
+    freturn ticks
+end
+
+function i8ToDateTime ,long
+    in req sdt	,i8
+    in opt fmt	,a14
+    endparams
+	
+proc
+    data dt		,System.Datetime
+    data ticks	,long
+
+    dt = new System.DateTime((sdt * 10), DateTimeKind.Utc)
+    dt = dt.AddYears(1969)
+    dt = TimeZone.CurrentTimeZone.ToLocalTime(dt); 
+    ticks = dt.Ticks
+    freturn ticks
+end
+
+function DateTimeToI8 ,long
+    in req dt	,System.DateTime
+    in opt fmt	,a14
+    endparams
+proc
+    data ticks	,i8
+    data basedt	,System.Datetime
+    data dtmp	,System.Datetime
+
+    basedt = new System.DateTime()
+    basedt = basedt.AddYears(1969)
+    dtmp = TimeZone.CurrentTimeZone.ToUniversalTime(dt);
+    ticks = dtmp.Subtract(basedt).Ticks / 10
+    freturn ticks
+end

--- a/HarmonyCore/Converters/Regexifier.dbl
+++ b/HarmonyCore/Converters/Regexifier.dbl
@@ -1,0 +1,172 @@
+import System
+import System.Collections.Generic
+import System.Linq
+import System.Text
+import System.Text.RegularExpressions
+import System.Threading.Tasks
+import System.Collections.Concurrent
+
+
+namespace Harmony.Core.Converters
+
+	public class RegexificationFactory
+        
+		private static FormatCache, @ConcurrentDictionary<string, RegexifiedExpression>, new ConcurrentDictionary<string, RegexifiedExpression>()
+
+		private static method RegexifyMe, @RegexifiedExpression
+			input, string 
+			matchLiteral, string 
+			endparams
+		proc
+			if(matchLiteral == "XZ") then
+			begin
+				mreturn FormatCache.GetOrAdd(input, lambda(str) { new RegexifiedExpression(input, RegexOptions.Compiled, matchLiteral.ToCharArray())}) 
+			end
+			else
+				mreturn new RegexifiedExpression(input, RegexOptions.None, matchLiteral.ToCharArray())
+		endmethod
+        
+		public static method RegexifyMe, @RegexifiedExpression
+			input, string 
+			endparams
+		proc
+			mreturn RegexifyMe(input, "XZ")
+		endmethod
+	endclass
+    
+	public class RegexifiedExpression implements IRegexifiedExpression
+
+		public virtual method GetData, String
+			input, String 
+			endparams
+		proc
+			;;TODO deal with leading and trailing negative in the format string and input string
+			data output = new StringBuilder()
+			data matchResult = InstantiatedRegex.Match(input)
+
+			if (!matchResult.Success)
+				mreturn string.Empty
+
+			data regexGroup, @Group
+			data i, int
+			for i from 1 thru matchResult.Groups.Count - 1
+			begin
+				regexGroup = matchResult.Groups[i]
+				if(input[regexGroup.Index] == 'Z') then
+				begin
+					output.Append(regexGroup.Value.Replace(" ", "0"))
+				end
+				else
+				begin
+					output.Append(regexGroup.Value)
+				end
+
+			end
+
+			mreturn output.ToString()
+		endmethod
+
+		private method ConstructMatchGroup, @StringBuilder
+			wipExpression, @StringBuilder 
+			length, int 
+			endparams
+		proc
+			wipExpression.Append(".{")
+			wipExpression.Append(length)
+			wipExpression.Append("}")
+			wipExpression.Append(')')
+			mreturn wipExpression
+		endmethod
+
+		private method ConstructRegex, string
+			input, string 
+			matchCharacter, @List<char> 
+			endparams
+		proc
+			data expression, @StringBuilder, new StringBuilder()
+			data escapedInput = Regex.Escape(input)
+			data groupStart, int, -1
+			data groupNumber, int, 0
+			data i, int
+			for i from 0 thru escapedInput.Length - 1
+			begin
+				data matchChar, boolean, matchCharacter.Contains(escapedInput[i])
+				if (matchChar && (groupStart == -1)) then
+				begin
+					expression.Append('(')
+					groupStart = i
+				end
+				else if (matchChar) then
+				begin
+                
+				end
+				else if (groupStart != -1) then
+				begin
+					expression = ConstructMatchGroup(expression, i - groupStart)
+					expression.Append(escapedInput[i])
+					groupStart = -1
+					^incr(groupNumber, true)
+				end
+				else
+				begin
+					expression.Append(escapedInput[i])
+				end
+			end
+			if (groupStart > -1)
+			begin
+				expression = ConstructMatchGroup(expression, i - groupStart)
+			end
+			mreturn expression.ToString()
+		endmethod
+
+		private _instantiatedRegex, @Lazy<Regex>
+        
+		public method RegexifiedExpression
+			inputExpression, string 
+			regexOpts, RegexOptions
+			matchLiteral, [#]char
+			endparams
+		proc
+			this.MatchLiteral = matchLiteral
+			this.InputExpression = inputExpression
+			_instantiatedRegex = new Lazy<Regex>(lambda() { new Regex(ConstructedRegex, regexOpts) })
+			ConstructedRegex = ConstructRegex(InputExpression, new List<char>(matchLiteral))
+		endmethod
+        
+		public readwrite property MatchLiteral, [#]char
+		public readwrite property InputExpression, string
+		public readwrite property ConstructedRegex, string
+		public property InstantiatedRegex, @Regex
+			method get
+			proc
+				mreturn _instantiatedRegex.Value
+			endmethod
+		endproperty
+
+
+	endclass
+
+	public interface IRegexifiedExpression
+    
+		property InputExpression, string
+			method get
+			endmethod
+		endproperty
+    
+		property ConstructedRegex, string
+			method get
+			endmethod
+		endproperty
+    
+		property InstantiatedRegex, @Regex
+			method get
+			endmethod
+		endproperty
+    
+		method GetData, string
+			input, string 
+			endparams
+		endmethod
+	endinterface
+
+endnamespace

--- a/HarmonyCore/Converters/SynergyDecimalConverter.dbl
+++ b/HarmonyCore/Converters/SynergyDecimalConverter.dbl
@@ -73,11 +73,9 @@ namespace Harmony.Core.Converters
 			required in formatMask, string
 			endparams
 		proc
-
-			;TODO: Needs implementing!
-			;throw new NotImplementedException("SynergyDecimalConverter.UnformatString is not implemented!")
-
-			mreturn 0
+			data resultValue, d28
+			resultValue = (a)RegexificationFactory.RegexifyMe(formatMask).GetData(stringValue)
+			mreturn resultValue
 
 		endmethod
 

--- a/HarmonyCore/Converters/SynergyDecimalDateConverter.dbl
+++ b/HarmonyCore/Converters/SynergyDecimalDateConverter.dbl
@@ -82,14 +82,13 @@ namespace Harmony.Core.Converters
 		;;; The Convert method is utilised by the _WPF_ framework when conversion of a databound source is required.  The SynergyDecimalDateConverter
 		;;; Convert method marshals the data from a Synergy Decimal type to a native <a href="https://docs.microsoft.com/en-us/dotnet/standard/clr" target="_blank">Command Language Runtime</a> Dateime type.
 		;;; The ConversionParameter value can be assigned the following:
-		;;;		FORMAT:YYYYMMDD - standard Synergy date format.
-		;;;		FORMAT:YYMMDD - reversed d6 date.
-		;;;		FORMAT:JULIAN - this will convert a decimal YYJJJ julian date type.
-		;;;		FORMAT:DDMMYY - accepts and converts a DDMMYY date.
-		;;;		FORMAT:DDMMYYYY - accepts and converts a DDMMYYYY date.
-		;;;		FORMAT:MMDDYY - accepts and converts a MMDDYY date.
-		;;;		FORMAT:MMDDYYYY - accepts and converts a MMDDYYYY date.
-		;;;		NODEFAULTODAY - prevents the code from defaulting to todays date.
+		;;;		YYYYMMDD - standard Synergy date format.
+		;;;		YYMMDD - reversed d6 date.
+		;;;		YYJJJ - this will convert a decimal julian date type.
+		;;;		DDMMYY - accepts and converts a DDMMYY date.
+		;;;		DDMMYYYY - accepts and converts a DDMMYYYY date.
+		;;;		MMDDYY - accepts and converts a MMDDYY date.
+		;;;		MMDDYYYY - accepts and converts a MMDDYYYY date.
 		;;; _NEWLINE_
 		;;; Convertion parameters can be combined using the '|' character, for example JULIANDATE|NODEFAULTODAY
 		;;; </remarks>
@@ -99,281 +98,18 @@ namespace Harmony.Core.Converters
 			parameter			,@Object
 			culture				,@System.Globalization.CultureInfo
 			endparams
-			
-			record 
-				dateLayout	,d8
-				dateLayouta	,a8 @dateLayout
-				year		,d4	@dateLayout
-				mon			,d2	@dateLayout + 4
-				day			,d2	@dateLayout + 6
-			endrecord	
-			record
-				iYear		,i4
-				iMon		,i4
-				iDay		,i4
-				tmpDate		,DateTime
-			endrecord
-			
-			record
-				gotDate			,Boolean
-				defaultToToday	,Boolean
-			endrecord
-			
 		proc
 			if (value == ^null)
 				mreturn ^null
 			
-			gotDate = false
-			defaultToToday = true
-			
-			if (value != ^null) DebugLogSession.Logging.LogTrace("Date Convert Value : {0}", value)
-			if (targetType != ^null) DebugLogSession.Logging.LogTrace("Date Convert Target type : {0}", targetType)
-			if (parameter != ^null) DebugLogSession.Logging.LogTrace("Date Convert Parameter {0}", Parameter)
-			
-			clear dateLayout
-			
+			data formatString = "YYYYMMDD"
 			;;do we have a parameter??
 			if (parameter != ^null)
 			begin
-				data p			,String, parameter.ToString()
-				
-				;;regular date
-				if (%instr(1, p.ToUpper(), 'FORMAT:YYYYMMDD'))
-				begin
-					DebugLogSession.Logging.LogTrace("Date Convert doing reverse D8 date processing")
-					data d8Date	,d8
-					d8Date = Convert.ToString(Value)
-					if (d8Date)
-					begin
-						year = d8Date(1:4)
-						mon = d8Date(5:2)
-						day = d8Date(7:2)
-						gotDate = true
-					end
-				end
-				
-				;;not a regular YYYYMMDD date field, do special processing
-				
-				if (%instr(1, p.ToUpper(), 'JULIANDATE') || %instr(1, p.ToUpper(), 'FORMAT:JULIAN'))
-				begin
-					DebugLogSession.Logging.LogTrace("Date Convert doing julian date processing")
-					data intVal		,int
-					data julDate	,d6
-					
-					try
-					begin
-						intVal = Convert.ToInt32(value)
-					end
-					catch (e, @Exception)
-					begin
-						DebugLogSession.Logging.LogTrace("Value passed to converter (Date) {0}: end value", value)
-						Symphony.Core.DebugLogSession.Logging.LogException(e,"SynergyDecimalDateConverter")
-					end
-					endtry
-					
-					if (intVal)
-					begin
-						julDate = intVal
-						xcall ConvertJulianDateValue(dateLayout,julDate,2,-8)
-						dateLayouta = dateLayout, 'XXXXXXXX'
-						gotDate = true
-					end
-				end
-				
-				if (%instr(1, p.ToUpper(), 'NONEREVDATE6') || %instr(1, p.ToUpper(), 'FORMAT:DDMMYY'))
-				begin
-					DebugLogSession.Logging.LogTrace("Date Convert doing none reverse D6 date processing")
-					data d6Date	,d6
-					
-					try
-					begin
-						d6Date = Convert.ToString(Value)
-					end
-					catch (e, @Exception)
-					begin
-						DebugLogSession.Logging.LogTrace("Value passed to converter (Date) :{0}: end value", value)
-						Symphony.Core.DebugLogSession.Logging.LogException(e,"SynergyDecimalDateConverter")
-					end
-					endtry
-					
-					if (d6Date)
-					begin
-						if (d6Date(5:2) > 50) then
-							year = 1900 + d6Date(5:2)
-						else
-							year = 2000 + d6Date(5:2)
-						mon = d6Date(3:2)
-						day = d6Date(1:2)
-						gotDate = true
-					end
-				end
-				
-				if (%instr(1, p.ToUpper(), 'FORMAT:YYMMDD'))
-				begin
-					DebugLogSession.Logging.LogTrace("Date Convert doing reverse D6 date processing")
-					data d6Date	,d6
-					
-					try
-					begin
-						d6Date = Convert.ToString(Value)
-					end
-					catch (e, @Exception)
-					begin
-						DebugLogSession.Logging.LogTrace("Value passed to converter (Date) :{0}: end value",value)
-						Symphony.Core.DebugLogSession.Logging.LogException(e,"SynergyDecimalDateConverter")
-					end
-					endtry
-					
-					if (d6Date)
-					begin
-						if (d6Date(1:2) > 50) then
-							year = 1900 + d6Date(1:2)
-						else
-							year = 2000 + d6Date(1:2)
-						mon = d6Date(3:2)
-						day = d6Date(5:2)
-						gotDate = true
-					end
-				end
-				
-				if (%instr(1, p.ToUpper(), 'FORMAT:DDMMYYYY'))
-				begin
-					DebugLogSession.Logging.LogTrace("Date Convert doing none-reverse D8 date processing")
-					data d8Date	,d8
-					
-					try
-					begin
-						d8Date = Convert.ToString(Value)
-					end
-					catch (e, @Exception)
-					begin
-						DebugLogSession.Logging.LogTrace("Value passed to converter (Date) :{0}: end value", value)
-						Symphony.Core.DebugLogSession.Logging.LogException(e,"SynergyDecimalDateConverter")
-					end
-					endtry
-					
-					if (d8Date)
-					begin
-						year = d8Date(5:4)
-						mon = d8Date(3:2)
-						day = d8Date(1:2)
-						gotDate = true
-					end
-				end
-				
-				if (%instr(1, p.ToUpper(), 'FORMAT:DDMMYY') && gotDate == false)
-				begin
-					DebugLogSession.Logging.LogTrace("Date Convert doing none-reverse D6 date processing")
-					data d6Date	,d6
-					
-					try
-					begin
-						d6Date = Convert.ToString(Value)
-					end
-					catch (e, @Exception)
-					begin
-						DebugLogSession.Logging.LogTrace("Value passed to converter (Date) :{0}:end value",value)
-						Symphony.Core.DebugLogSession.Logging.LogException(e,"SynergyDecimalDateConverter")
-					end
-					endtry
-					
-					if (d6Date)
-					begin
-						year = 2000 + d6Date(5:2)
-						mon = d6Date(3:2)
-						day = d6Date(1:2)
-						gotDate = true
-					end
-				end
-				
-				if (%instr(1, p.ToUpper(), 'FORMAT:MMDDYYYY'))
-				begin
-					DebugLogSession.Logging.LogTrace("Date Convert doing none-reverse D8 US date processing")
-					data d8Date	,d8
-					
-					try
-					begin
-						d8Date = Convert.ToString(Value)
-					end
-					catch (e, @Exception)
-					begin
-						DebugLogSession.Logging.LogTrace("Value passed to converter (Date) :{0}:end value",value)
-						Symphony.Core.DebugLogSession.Logging.LogException(e,"SynergyDecimalDateConverter")
-					end
-					endtry
-					
-					if (d8Date)
-					begin
-						year = d8Date(5:4)
-						mon = d8Date(1:2)
-						day = d8Date(3:2)
-						gotDate = true
-					end
-				end
-				
-				if (%instr(1, p.ToUpper(), 'FORMAT:MMDDYY') && gotDate == false)
-				begin
-					DebugLogSession.Logging.LogTrace("Date Convert doing none-reverse D6 US date processing")
-					data d6Date	,d6
-					
-					try
-					begin
-						d6Date = Convert.ToString(Value)
-					end
-					catch (e, @Exception)
-					begin
-						DebugLogSession.Logging.LogTrace("Value passed to converter (Date) :{0}:end value",value)
-						Symphony.Core.DebugLogSession.Logging.LogException(e,"SynergyDecimalDateConverter")
-					end
-					endtry
-					
-					if (d6Date)
-					begin
-						year = 2000 + d6Date(5:2)
-						mon = d6Date(1:2)
-						day = d6Date(3:2)
-						gotDate = true
-					end
-				end
-				
-				if (%instr(1, p.ToUpper(), 'NODEFAULTODAY'))
-				begin
-					defaultToToday = false
-				end
-				
+				formatString = parameter.ToString()
 			end
-			
-			if (!gotDate)
-			begin
-				dateLayouta = Convert.ToString(Value)
-			end
-			
-			if (dateLayout) then
-			begin
-				iYear = year
-				iMon = mon
-				iDay = day
-				try
-				begin
-					tmpDate = new DateTime(iYear, iMon, iDay)
-				end
-				catch (e, @Exception)
-				begin
-					DebugLogSession.Logging.LogTrace("Value passed to converter (Date) :{0}:end value",value)
-					Symphony.Core.DebugLogSession.Logging.LogException(e,"SynergyDecimalDateConverter")
-				end
-				endtry
-			end
-			else
-				tmpDate=datetime.Today
-			
-			DebugLogSession.Logging.LogTrace("Date Convert resulting date : " + tmpDate.ToString())
-			
-			if (!dateLayout && defaultToToday == false) then
-				mreturn ^null
-			else
-				mreturn (Object) tmpDate
-			
+
+			mreturn new DateTime(%DecToDateTime((d)value, formatString))
 		endmethod
 		
 		;;; <summary>
@@ -387,13 +123,13 @@ namespace Harmony.Core.Converters
 		;;; The Convert method is utilised by the _WPF_ framework when conversion of a databound source is required.  The SynergyDecimalDateConverter
 		;;; ConvertBack method marshals the data from a native <a href="https://docs.microsoft.com/en-us/dotnet/standard/clr" target="_blank">Command Language Runtime</a> DateTime type to a Synergy Decimal type
 		;;; The ConversionParameter value can be assigned the following:
-		;;;		FORMAT:YYYYMMDD - standard Synergy date format.
-		;;;		FORMAT:YYMMDD - reversed d6 date.
-		;;;		FORMAT:JULIAN - this will convert a decimal YYJJJ julian date type.
-		;;;		FORMAT:DDMMYY - accepts and converts a DDMMYY date.
-		;;;		FORMAT:DDMMYYYY - accepts and converts a DDMMYYYY date.
-		;;;		FORMAT:MMDDYY - accepts and converts a DDMMYY date.
-		;;;		FORMAT:MMDDYYYY - accepts and converts a DDMMYYYY date.
+		;;;		YYYYMMDD - standard Synergy date format.
+		;;;		YYMMDD - reversed d6 date.
+		;;;		YYJJJ - this will convert a decimal YYJJJ julian date type.
+		;;;		DDMMYY - accepts and converts a DDMMYY date.
+		;;;		DDMMYYYY - accepts and converts a DDMMYYYY date.
+		;;;		MMDDYY - accepts and converts a DDMMYY date.
+		;;;		MMDDYYYY - accepts and converts a DDMMYYYY date.
 		;;; </remarks>
 		public static method ConvertBack	,@Object
 			value				,@Object
@@ -401,107 +137,22 @@ namespace Harmony.Core.Converters
 			parameter			,@Object
 			culture				,@System.Globalization.CultureInfo
 			endparams
-			record 
-				dateLayout	,d8
-				year		,d4	@dateLayout
-				mon			,d2	@dateLayout + 4
-				day			,d2	@dateLayout + 6
-				
-				nonRevDate	,d8
-				nrDay		,d2@nonRevDate
-				nrMon		,d2@nonRevDate+2
-				nrYear		,d4@nonRevDate+4
-				
-				tmpDate		,DateTime
-			endrecord	
 		proc
 			if (value == ^null)
 			begin
-				dateLayout = 0
+				data dateLayout, d8, 0
 				mreturn (Object)dateLayout
 			end
 			
-			if (value != ^null) DebugLogSession.Logging.LogTrace("Date ConvertBack Value : " + value.ToString())
-			if (targetType != ^null) DebugLogSession.Logging.LogTrace("Date ConvertBack Target type : " + targetType.ToString())
-			if (parameter != ^null) DebugLogSession.Logging.LogTrace("Date ConvertBack Parameter : " + Parameter.ToString())
-			
-			tmpDate = Convert.ToDateTime(value)
-			year = tmpDate.Year
-			mon = tmpDate.Month
-			day = tmpDate.Day
-			
+			data formatString = "YYYYMMDD"
+			;;do we have a parameter??
 			if (parameter != ^null)
 			begin
-				data p			,String, parameter.ToString()
-				
-				;;not a regular YYYYMMDD date field, do special processing
-				
-				if (%instr(1, p.ToUpper(), 'FORMAT:JULIAN'))
-				begin
-					DebugLogSession.Logging.LogTrace("Date ConvertBack doing julian date processing")
-					data julDate	,d6
-					nrDay = day
-					nrMon = mon
-					nrYear = year
-					xcall ConvertJulianDateValue(nonRevDate,julDate,1)
-					mreturn (Object)julDate
-				end
-				
-				if (%instr(1, p.ToUpper(), 'FORMAT:YYMMDD'))
-				begin
-					DebugLogSession.Logging.LogTrace("Date ConvertBack doing YYMMDD date processing")
-					data d6Date	,d6
-					d6Date(1:2) = year(3:2)
-					d6Date(3:2) = mon
-					d6Date(5:2) = day
-					mreturn (Object)d6Date
-				end
-				
-				if (%instr(1, p.ToUpper(), 'FORMAT:DDMMYY'))
-				begin
-					DebugLogSession.Logging.LogTrace("Date ConvertBack doing DDMMYY date processing")
-					data d6Date	,d6
-					d6Date(1:2) = day
-					d6Date(3:2) = mon
-					d6Date(5:2) = year(3:2)
-					mreturn (Object)d6Date
-				end
-				
-				if (%instr(1, p.ToUpper(), 'FORMAT:DDMMYYYY'))
-				begin
-					DebugLogSession.Logging.LogTrace("Date ConvertBack doing DDMMYYYY date processing")
-					data d8Date	,d8
-					d8Date(1:2) = day
-					d8Date(3:2) = mon
-					d8Date(5:4) = year(3:2)
-					mreturn (Object)d8Date
-				end
-				
-				if (%instr(1, p.ToUpper(), 'FORMAT:MMMMYY'))
-				begin
-					DebugLogSession.Logging.LogTrace("Date ConvertBack doing MMDDYY date processing")
-					data d6Date	,d6
-					d6Date(3:2) = day
-					d6Date(1:2) = mon
-					d6Date(5:2) = year(3:2)
-					mreturn (Object)d6Date
-				end
-				
-				if (%instr(1, p.ToUpper(), 'FORMAT:MMDDYYYY'))
-				begin
-					DebugLogSession.Logging.LogTrace("Date ConvertBack doing MMDDYYYY date processing")
-					data d8Date	,d8
-					d8Date(3:2) = day
-					d8Date(1:2) = mon
-					d8Date(5:4) = year(3:2)
-					mreturn (Object)d8Date
-				end
-				
+				formatString = parameter.ToString()
 			end
-			
-			DebugLogSession.Logging.LogTrace("Date ConvertBack resulting date : " + %string(dateLayout))
-			
-			mreturn (Object)dateLayout
+
+			mreturn (@Object)%DateTimeToDec((DateTime)value, formatString)
+
 		endmethod
 	endclass
 	

--- a/HarmonyCore/HarmonyCore.synproj
+++ b/HarmonyCore/HarmonyCore.synproj
@@ -83,6 +83,7 @@
     <Compile Include="Context\ThreadedContextPool.dbl" />
     <Compile Include="Converters\CustomDateRoutines.dbl" />
     <Compile Include="Converters\ILiteralFormatter.dbl" />
+    <Compile Include="Converters\Regexifier.dbl" />
     <Compile Include="Converters\SynergyAlphaConverter.dbl" />
     <Compile Include="Converters\SynergyDecimalConverter.dbl" />
     <Compile Include="Converters\SynergyDecimalDateConverter.dbl" />

--- a/Services.Test/UnitTests/HandCrafted.dbl
+++ b/Services.Test/UnitTests/HandCrafted.dbl
@@ -50,6 +50,7 @@ import Services
 import Services.Test.Models
 import Microsoft.Extensions.DependencyInjection
 import Harmony.Core.EF.Extensions
+import Harmony.Core.Converters
 import Services.Models
 namespace Services.Test.UnitTests
 
@@ -635,6 +636,16 @@ namespace Services.Test.UnitTests
             end
 
         endmethod
+
+		{TestMethod}
+		public method Regexifier_Simple, void
+		proc
+			data resultValue, d28
+			data expected, d28, 5555555555
+			resultValue = (a)RegexificationFactory.RegexifyMe("(XXX) XXX-XXXX").GetData("(555) 555-5555")
+			Assert.AreEqual(resultValue, expected)
+		endmethod
+
 
     endclass
 


### PR DESCRIPTION
this fixes #28 for decimals, but not yet for implied decimals. We're using a new helper class called Regexifier that changes a format mask into a regex and provides the ability to extract that data into a synergy decimal (currently limited to d28)