### PR TITLE
Fixes for TraditionalBridge Unit Tests

### DIFF
--- a/Services.Controllers/CustomerExsController.dbl
+++ b/Services.Controllers/CustomerExsController.dbl
@@ -147,6 +147,7 @@ namespace Services.Controllers
             {FromBody}
             required in aCustomerEx, @CustomerEx
         proc
+
             ;; Validate inbound data
             if (!ModelState.IsValid)
                 mreturn ValidationHelper.ReturnValidationError(ModelState)

--- a/Services.Controllers/CustomersController.dbl
+++ b/Services.Controllers/CustomersController.dbl
@@ -207,6 +207,7 @@ namespace Services.Controllers
             {FromBody}
             required in aCustomer, @Customer
         proc
+
             ;; Validate inbound data
             if (!ModelState.IsValid)
                 mreturn ValidationHelper.ReturnValidationError(ModelState)

--- a/Services.Controllers/ItemsController.dbl
+++ b/Services.Controllers/ItemsController.dbl
@@ -227,6 +227,7 @@ namespace Services.Controllers
             {FromBody}
             required in aItem, @Item
         proc
+
             ;; Validate inbound data
             if (!ModelState.IsValid)
                 mreturn ValidationHelper.ReturnValidationError(ModelState)

--- a/Services.Controllers/OrderItemsController.dbl
+++ b/Services.Controllers/OrderItemsController.dbl
@@ -214,6 +214,7 @@ namespace Services.Controllers
             {FromBody}
             required in aOrderItem, @OrderItem
         proc
+
             ;; Validate inbound data
             if (!ModelState.IsValid)
                 mreturn ValidationHelper.ReturnValidationError(ModelState)

--- a/Services.Controllers/OrdersController.dbl
+++ b/Services.Controllers/OrdersController.dbl
@@ -207,6 +207,7 @@ namespace Services.Controllers
             {FromBody}
             required in aOrder, @Order
         proc
+
             ;; Validate inbound data
             if (!ModelState.IsValid)
                 mreturn ValidationHelper.ReturnValidationError(ModelState)

--- a/Services.Controllers/VendorsController.dbl
+++ b/Services.Controllers/VendorsController.dbl
@@ -207,6 +207,7 @@ namespace Services.Controllers
             {FromBody}
             required in aVendor, @Vendor
         proc
+
             ;; Validate inbound data
             if (!ModelState.IsValid)
                 mreturn ValidationHelper.ReturnValidationError(ModelState)

--- a/Services.Test/UnitTests/CustomerExTests.dbl
+++ b/Services.Test/UnitTests/CustomerExTests.dbl
@@ -174,7 +174,6 @@ namespace Services.Test.UnitTests
 
             ;;Deserialize the JSON into a CustomerEx object
             doCustomerEx = JsonConvert.DeserializeObject<CustomerEx>(getResult)
-
             Assert.AreEqual(doCustomerEx.Extradata, "Y")
 
             ;;Update one non-existant property in the customer

--- a/Services.Test/UnitTests/CustomerTests.dbl
+++ b/Services.Test/UnitTests/CustomerTests.dbl
@@ -306,7 +306,6 @@ namespace Services.Test.UnitTests
 
             ;;Deserialize the JSON into a Customer object
             doCustomer = JsonConvert.DeserializeObject<Customer>(getResult)
-
             Assert.AreEqual(doCustomer.Name, "Y")
 
             ;;Update one non-existant property in the customer

--- a/Services.Test/UnitTests/ItemTests.dbl
+++ b/Services.Test/UnitTests/ItemTests.dbl
@@ -263,7 +263,6 @@ namespace Services.Test.UnitTests
 
             ;;Deserialize the JSON into a Item object
             doItem = JsonConvert.DeserializeObject<Item>(getResult)
-
             Assert.AreEqual(doItem.LatinName, "Y")
 
             ;;Update one non-existant property in the customer

--- a/Services.Test/UnitTests/OrderItemTests.dbl
+++ b/Services.Test/UnitTests/OrderItemTests.dbl
@@ -249,7 +249,6 @@ namespace Services.Test.UnitTests
 
             ;;Deserialize the JSON into a OrderItem object
             doOrderItem = JsonConvert.DeserializeObject<OrderItem>(getResult)
-
             Assert.AreEqual(doOrderItem.QuantityOrdered, 8)
 
             ;;Update one non-existant property in the customer

--- a/Services.Test/UnitTests/OrderTests.dbl
+++ b/Services.Test/UnitTests/OrderTests.dbl
@@ -248,7 +248,6 @@ namespace Services.Test.UnitTests
 
             ;;Deserialize the JSON into a Order object
             doOrder = JsonConvert.DeserializeObject<Order>(getResult)
-
             Assert.AreEqual(doOrder.PlacedBy, "Y")
 
             ;;Update one non-existant property in the customer

--- a/Services.Test/UnitTests/VendorTests.dbl
+++ b/Services.Test/UnitTests/VendorTests.dbl
@@ -219,7 +219,6 @@ namespace Services.Test.UnitTests
 
             ;;Deserialize the JSON into a Vendor object
             doVendor = JsonConvert.DeserializeObject<Vendor>(getResult)
-
             Assert.AreEqual(doVendor.Name, "Y")
 
             ;;Update one non-existant property in the customer

--- a/Templates/TraditionalBridge/InterfaceMethodDispatchers.tpl
+++ b/Templates/TraditionalBridge/InterfaceMethodDispatchers.tpl
@@ -146,7 +146,7 @@ namespace <NAMESPACE>.<INTERFACE_NAME>
             <IF COLLECTION_ARRAY>
             ;;Temp structure tempstr<COUNTER_1_VALUE>
             structure tempstr<COUNTER_1_VALUE>
-                arry, <IF STRUCTURE>@<ParameterStructureNoplural><ELSE>[1]<PARAMETER_DEFINITION></IF STRUCTURE>
+                arry, <IF STRUCTURE>@<ParameterStructureNoplural><ELSE><PARAMETER_DEFINITION></IF STRUCTURE>
             endstructure
 
             </IF COLLECTION_ARRAY>
@@ -252,11 +252,7 @@ namespace <NAMESPACE>.<INTERFACE_NAME>
             arg<COUNTER_1_VALUE>Handle = %mem_proc(DM_ALLOC,4)
         <ELSE COLLECTION>
             <IF COLLECTION_HANDLE OR COLLECTION_ARRAY>
-            <IF STRUCTURE>
             arg<COUNTER_1_VALUE>Handle = %mem_proc(DM_ALLOC,<PARAMETER_SIZE>)
-            <ELSE>
-            arg<COUNTER_1_VALUE>Handle = %mem_proc(DM_ALLOC,1)
-            </IF>
             </IF>
         </IF>
     </IF IN_OR_INOUT>
@@ -269,7 +265,7 @@ namespace <NAMESPACE>.<INTERFACE_NAME>
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            <IF SUBROUTINE>xcall <ELSE>returnValue = %</IF SUBROUTINE><METHOD_ROUTINE>(<COUNTER_1_RESET><PARAMETER_LOOP><COUNTER_1_INCREMENT><IF HANDLE OR BINARY_HANDLE>arg<COUNTER_1_VALUE>Handle<,><ELSE><IF COLLECTION><IF COLLECTION_ARRAY>^m(<IF STRUCTURE>str<ParameterStructureNoplural><ELSE>tempstr<COUNTER_1_VALUE>.arry</IF STRUCTURE>,arg<COUNTER_1_VALUE>Handle)<,></IF COLLECTION_ARRAY><IF COLLECTION_HANDLE>arg<COUNTER_1_VALUE>Handle<,></IF COLLECTION_HANDLE><IF COLLECTION_ARRAYLIST>arg<COUNTER_1_VALUE><,></IF COLLECTION_ARRAYLIST><ELSE>arg<COUNTER_1_VALUE><,></IF COLLECTION></IF></PARAMETER_LOOP>)
+            <IF SUBROUTINE>xcall <ELSE>returnValue = %</IF SUBROUTINE><METHOD_ROUTINE>(<COUNTER_1_RESET><PARAMETER_LOOP><COUNTER_1_INCREMENT><IF HANDLE OR BINARY_HANDLE>arg<COUNTER_1_VALUE>Handle<,><ELSE><IF COLLECTION><IF COLLECTION_ARRAY>^marray(<IF STRUCTURE>str<ParameterStructureNoplural><ELSE>tempstr<COUNTER_1_VALUE>.arry</IF STRUCTURE>,arg<COUNTER_1_VALUE>Handle)<,></IF COLLECTION_ARRAY><IF COLLECTION_HANDLE>arg<COUNTER_1_VALUE>Handle<,></IF COLLECTION_HANDLE><IF COLLECTION_ARRAYLIST>arg<COUNTER_1_VALUE><,></IF COLLECTION_ARRAYLIST><ELSE>arg<COUNTER_1_VALUE><,></IF COLLECTION></IF></PARAMETER_LOOP>)
 ;//
 ;//=========================================================================================================================
 ;// Build the JSON response

--- a/TraditionalBridge.Test/MethodDispatchers/AutoTimeMethodDispachers.dbl
+++ b/TraditionalBridge.Test/MethodDispatchers/AutoTimeMethodDispachers.dbl
@@ -184,7 +184,7 @@ namespace TraditionalBridge.Test.AutoTime
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall AutoTimeArray(^m(strTimekey,arg1Handle))
+            xcall AutoTimeArray(^marray(strTimekey,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT TIMEKEY [*]structure @Timekey)

--- a/TraditionalBridge.Test/MethodDispatchers/BinaryTransferMethodDispachers.dbl
+++ b/TraditionalBridge.Test/MethodDispatchers/BinaryTransferMethodDispachers.dbl
@@ -292,7 +292,7 @@ namespace TraditionalBridge.Test.BinaryTransfer
 
             ;;Temp structure tempstr1
             structure tempstr1
-                arry, [1]I1
+                arry, I1
             endstructure
 
 
@@ -310,7 +310,7 @@ namespace TraditionalBridge.Test.BinaryTransfer
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall getbytea(^m(tempstr1.arry,arg1Handle))
+            xcall getbytea(^marray(tempstr1.arry,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED OUT amybyte [*]I1)
@@ -424,7 +424,7 @@ namespace TraditionalBridge.Test.BinaryTransfer
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall getstructa(^m(strInteger,arg1Handle))
+            xcall getstructa(^marray(strInteger,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED OUT amyintegers [*]structure @Integer)
@@ -514,7 +514,7 @@ namespace TraditionalBridge.Test.BinaryTransfer
 
             ;;Temp structure tempstr1
             structure tempstr1
-                arry, [1]I4
+                arry, I4
             endstructure
 
 
@@ -527,12 +527,12 @@ namespace TraditionalBridge.Test.BinaryTransfer
 
             ;;Argument 1 (REQUIRED OUT amyuint [*]I4)
 
-            arg1Handle = %mem_proc(DM_ALLOC,1)
+            arg1Handle = %mem_proc(DM_ALLOC,4)
 
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall getuinta(^m(tempstr1.arry,arg1Handle))
+            xcall getuinta(^marray(tempstr1.arry,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED OUT amyuint [*]I4)
@@ -622,7 +622,7 @@ namespace TraditionalBridge.Test.BinaryTransfer
 
             ;;Temp structure tempstr1
             structure tempstr1
-                arry, [1]I2
+                arry, I2
             endstructure
 
 
@@ -635,12 +635,12 @@ namespace TraditionalBridge.Test.BinaryTransfer
 
             ;;Argument 1 (REQUIRED OUT amyushort [*]I2)
 
-            arg1Handle = %mem_proc(DM_ALLOC,1)
+            arg1Handle = %mem_proc(DM_ALLOC,2)
 
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall getushorta(^m(tempstr1.arry,arg1Handle))
+            xcall getushorta(^marray(tempstr1.arry,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED OUT amyushort [*]I2)
@@ -680,7 +680,7 @@ namespace TraditionalBridge.Test.BinaryTransfer
 
             ;;Temp structure tempstr1
             structure tempstr1
-                arry, [1]I1
+                arry, I1
             endstructure
 
 
@@ -702,7 +702,7 @@ namespace TraditionalBridge.Test.BinaryTransfer
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall setbytea(^m(tempstr1.arry,arg1Handle))
+            xcall setbytea(^marray(tempstr1.arry,arg1Handle))
         endmethod
 
     endclass
@@ -737,7 +737,7 @@ namespace TraditionalBridge.Test.BinaryTransfer
 
             ;;Temp structure tempstr1
             structure tempstr1
-                arry, [1]I2
+                arry, I2
             endstructure
 
 
@@ -759,7 +759,7 @@ namespace TraditionalBridge.Test.BinaryTransfer
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall setushorta(^m(tempstr1.arry,arg1Handle))
+            xcall setushorta(^marray(tempstr1.arry,arg1Handle))
         endmethod
 
     endclass

--- a/TraditionalBridge.Test/MethodDispatchers/EncryptMethodDispachers.dbl
+++ b/TraditionalBridge.Test/MethodDispatchers/EncryptMethodDispachers.dbl
@@ -538,22 +538,22 @@ namespace TraditionalBridge.Test.Encrypt
 
             ;;Temp structure tempstr6
             structure tempstr6
-                arry, [1]D5
+                arry, D5
             endstructure
 
             ;;Temp structure tempstr7
             structure tempstr7
-                arry, [1]A20
+                arry, A20
             endstructure
 
             ;;Temp structure tempstr8
             structure tempstr8
-                arry, [1]D10.3
+                arry, D10.3
             endstructure
 
             ;;Temp structure tempstr9
             structure tempstr9
-                arry, [1]I4
+                arry, I4
             endstructure
 
 
@@ -619,7 +619,7 @@ namespace TraditionalBridge.Test.Encrypt
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall function_eight(arg1,arg2,arg3,arg4,arg5,^m(tempstr6.arry,arg6Handle),^m(tempstr7.arry,arg7Handle),^m(tempstr8.arry,arg8Handle),^m(tempstr9.arry,arg9Handle))
+            xcall function_eight(arg1,arg2,arg3,arg4,arg5,^marray(tempstr6.arry,arg6Handle),^marray(tempstr7.arry,arg7Handle),^marray(tempstr8.arry,arg8Handle),^marray(tempstr9.arry,arg9Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (OPTIONAL INOUT p1 A5)

--- a/TraditionalBridge.Test/MethodDispatchers/LrgPktsMethodDispachers.dbl
+++ b/TraditionalBridge.Test/MethodDispatchers/LrgPktsMethodDispachers.dbl
@@ -79,7 +79,7 @@ namespace TraditionalBridge.Test.LrgPkts
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall P1StrAryO64k(^m(strDataset,arg1Handle))
+            xcall P1StrAryO64k(^marray(strDataset,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT DATASET [*]structure @Dataset)
@@ -162,7 +162,7 @@ namespace TraditionalBridge.Test.LrgPkts
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall P2StrArysO64k(^m(strAddres,arg1Handle),^m(strPerfstruct,arg2Handle))
+            xcall P2StrArysO64k(^marray(strAddres,arg1Handle),^marray(strPerfstruct,arg2Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT ADDRESS [*]structure @Addres)
@@ -231,7 +231,7 @@ namespace TraditionalBridge.Test.LrgPkts
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall P3StrAry(^m(strAddres,arg1Handle))
+            xcall P3StrAry(^marray(strAddres,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT ADDRESS [*]structure @Addres)
@@ -314,7 +314,7 @@ namespace TraditionalBridge.Test.LrgPkts
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall P4StrAry(^m(strPerfstruct,arg1Handle),^m(strAddres,arg2Handle))
+            xcall P4StrAry(^marray(strPerfstruct,arg1Handle),^marray(strAddres,arg2Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT PERFSTRUCT [*]structure @Perfstruct)
@@ -429,7 +429,7 @@ namespace TraditionalBridge.Test.LrgPkts
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall getStructArray(^m(strPerfstruct,arg1Handle))
+            xcall getStructArray(^marray(strPerfstruct,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED OUT PERFSTRUCT [*]structure @Perfstruct)
@@ -499,7 +499,7 @@ namespace TraditionalBridge.Test.LrgPkts
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall setStructArray(^m(strPerfstruct,arg1Handle),arg2)
+            xcall setStructArray(^marray(strPerfstruct,arg1Handle),arg2)
         endmethod
 
     endclass

--- a/TraditionalBridge.Test/MethodDispatchers/WCFieldsMethodDispachers.dbl
+++ b/TraditionalBridge.Test/MethodDispatchers/WCFieldsMethodDispachers.dbl
@@ -262,7 +262,7 @@ namespace TraditionalBridge.Test.WCFields
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall teststr9(arg1,^m(strStrtest3,arg2Handle),arg3)
+            xcall teststr9(arg1,^marray(strStrtest3,arg2Handle),arg3)
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT p1de7 D7)

--- a/TraditionalBridge.Test/MethodDispatchers/ZDateTimeMethodDispachers.dbl
+++ b/TraditionalBridge.Test/MethodDispatchers/ZDateTimeMethodDispachers.dbl
@@ -227,7 +227,7 @@ namespace TraditionalBridge.Test.ZDateTime
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall DateTimex(^m(strDatetimestr,arg1Handle))
+            xcall DateTimex(^marray(strDatetimestr,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT DATETIMESTR [*]structure @Datetimestr)

--- a/TraditionalBridge.Test/MethodDispatchers/data64kMethodDispachers.dbl
+++ b/TraditionalBridge.Test/MethodDispatchers/data64kMethodDispachers.dbl
@@ -79,7 +79,7 @@ namespace TraditionalBridge.Test.data64k
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall P1StrAryO64k(^m(strDataset,arg1Handle))
+            xcall P1StrAryO64k(^marray(strDataset,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT DATASET [*]structure @Dataset)

--- a/TraditionalBridge.Test/MethodDispatchers/smcMethodDispachers.dbl
+++ b/TraditionalBridge.Test/MethodDispatchers/smcMethodDispachers.dbl
@@ -350,22 +350,22 @@ namespace TraditionalBridge.Test.smc
 
             ;;Temp structure tempstr6
             structure tempstr6
-                arry, [1]D5
+                arry, D5
             endstructure
 
             ;;Temp structure tempstr7
             structure tempstr7
-                arry, [1]A20
+                arry, A20
             endstructure
 
             ;;Temp structure tempstr8
             structure tempstr8
-                arry, [1]D10.3
+                arry, D10.3
             endstructure
 
             ;;Temp structure tempstr9
             structure tempstr9
-                arry, [1]I4
+                arry, I4
             endstructure
 
 
@@ -431,7 +431,7 @@ namespace TraditionalBridge.Test.smc
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall function_eight(arg1,arg2,arg3,arg4,arg5,^m(tempstr6.arry,arg6Handle),^m(tempstr7.arry,arg7Handle),^m(tempstr8.arry,arg8Handle),^m(tempstr9.arry,arg9Handle))
+            xcall function_eight(arg1,arg2,arg3,arg4,arg5,^marray(tempstr6.arry,arg6Handle),^marray(tempstr7.arry,arg7Handle),^marray(tempstr8.arry,arg8Handle),^marray(tempstr9.arry,arg9Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (OPTIONAL INOUT p1 A5)

--- a/TraditionalBridge.Test/MethodDispatchers/strtestsMethodDispachers.dbl
+++ b/TraditionalBridge.Test/MethodDispatchers/strtestsMethodDispachers.dbl
@@ -384,7 +384,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall passLargePacket(^m(strAddres,arg1Handle),^m(strPerfstruct,arg2Handle))
+            xcall passLargePacket(^marray(strAddres,arg1Handle),^marray(strPerfstruct,arg2Handle))
         endmethod
 
     endclass
@@ -489,7 +489,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall getStructArray(^m(strPerfstruct,arg1Handle))
+            xcall getStructArray(^marray(strPerfstruct,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED OUT PERFSTRUCT [*]structure @Perfstruct)
@@ -559,7 +559,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall inStructArray(^m(strPerfstruct,arg1Handle),arg2)
+            xcall inStructArray(^marray(strPerfstruct,arg1Handle),arg2)
         endmethod
 
     endclass
@@ -624,7 +624,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall inoutStructArray(^m(strPerfstruct,arg1Handle),arg2)
+            xcall inoutStructArray(^marray(strPerfstruct,arg1Handle),arg2)
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT PERFSTRUCT [*]structure @Perfstruct)
@@ -694,7 +694,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall outStructArray(^m(strPerfstruct,arg1Handle),arg2)
+            xcall outStructArray(^marray(strPerfstruct,arg1Handle),arg2)
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED OUT PERFSTRUCT [*]structure @Perfstruct)
@@ -769,7 +769,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall setStructArray(^m(strPerfstruct,arg1Handle),arg2)
+            xcall setStructArray(^marray(strPerfstruct,arg1Handle),arg2)
         endmethod
 
     endclass
@@ -842,7 +842,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            returnValue = %syninsurance(arg1,^m(strTrSyninsRet,arg2Handle),arg3)
+            returnValue = %syninsurance(arg1,^marray(strTrSyninsRet,arg2Handle),arg3)
 
             ;;Function return value
             serializer.ArgumentData(0,returnValue,FieldDataType.IntegerField,4,0,false)
@@ -1039,7 +1039,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall teststr10(arg1,^m(strStrtest3,arg2Handle))
+            xcall teststr10(arg1,^marray(strStrtest3,arg2Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT strtest4 structure @Strtest4)
@@ -1120,7 +1120,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall teststr11(^m(strStrtest3,arg1Handle),arg2)
+            xcall teststr11(^marray(strStrtest3,arg1Handle),arg2)
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT STRTEST3 [*]structure @Strtest3)
@@ -1247,7 +1247,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall teststr13(^m(strStrtest12,arg1Handle))
+            xcall teststr13(^marray(strStrtest12,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT strtest12 [*]structure @Strtest12)
@@ -2153,7 +2153,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall teststr30(^m(strStrtest30,arg1Handle))
+            xcall teststr30(^marray(strStrtest30,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT STRTEST30 [*]structure @Strtest30)
@@ -2217,7 +2217,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall teststr31(^m(strStrtest31,arg1Handle))
+            xcall teststr31(^marray(strStrtest31,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT STRTEST31 [*]structure @Strtest31)
@@ -2576,7 +2576,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall teststr7(^m(strStrtest7,arg1Handle))
+            xcall teststr7(^marray(strStrtest7,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT strtest7 [*]structure @Strtest7)
@@ -2640,7 +2640,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall teststr8(^m(strStrtest3,arg1Handle))
+            xcall teststr8(^marray(strStrtest3,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT strtest3 [*]structure @Strtest3)
@@ -2716,7 +2716,7 @@ namespace TraditionalBridge.Test.strtests
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall teststr9(arg1,^m(strStrtest3,arg2Handle),arg3)
+            xcall teststr9(arg1,^marray(strStrtest3,arg2Handle),arg3)
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT p1de7 D7)

--- a/TraditionalBridge.Test/MethodDispatchers/syntstMethodDispachers.dbl
+++ b/TraditionalBridge.Test/MethodDispatchers/syntstMethodDispachers.dbl
@@ -97,7 +97,7 @@ namespace TraditionalBridge.Test.syntst
 
             ;;Temp structure tempstr21
             structure tempstr21
-                arry, [1]A7
+                arry, A7
             endstructure
 
 
@@ -203,7 +203,7 @@ namespace TraditionalBridge.Test.syntst
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall array21(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13,arg14,arg15,arg16,arg17,arg18,arg19,arg20,^m(tempstr21.arry,arg21Handle),arg22)
+            xcall array21(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13,arg14,arg15,arg16,arg17,arg18,arg19,arg20,^marray(tempstr21.arry,arg21Handle),arg22)
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 21 (REQUIRED INOUT p21 [*]A7)
@@ -533,7 +533,7 @@ namespace TraditionalBridge.Test.syntst
 
             ;;Temp structure tempstr1
             structure tempstr1
-                arry, [1]A20
+                arry, A20
             endstructure
 
 
@@ -555,7 +555,7 @@ namespace TraditionalBridge.Test.syntst
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall function_sixteen(^m(tempstr1.arry,arg1Handle))
+            xcall function_sixteen(^marray(tempstr1.arry,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (OPTIONAL INOUT p1 [*]A20)
@@ -3131,7 +3131,7 @@ namespace TraditionalBridge.Test.syntst
 
             ;;Temp structure tempstr1
             structure tempstr1
-                arry, [1]D5
+                arry, D5
             endstructure
 
 
@@ -3153,7 +3153,7 @@ namespace TraditionalBridge.Test.syntst
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall msc_arytst_dec(^m(tempstr1.arry,arg1Handle))
+            xcall msc_arytst_dec(^marray(tempstr1.arry,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT p1 [*]D5)
@@ -3193,7 +3193,7 @@ namespace TraditionalBridge.Test.syntst
 
             ;;Temp structure tempstr1
             structure tempstr1
-                arry, [1]D10.3
+                arry, D10.3
             endstructure
 
 
@@ -3215,7 +3215,7 @@ namespace TraditionalBridge.Test.syntst
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall msc_arytst_imp(^m(tempstr1.arry,arg1Handle))
+            xcall msc_arytst_imp(^marray(tempstr1.arry,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT p1 [*]D10.3)
@@ -3255,7 +3255,7 @@ namespace TraditionalBridge.Test.syntst
 
             ;;Temp structure tempstr1
             structure tempstr1
-                arry, [1]I4
+                arry, I4
             endstructure
 
 
@@ -3277,7 +3277,7 @@ namespace TraditionalBridge.Test.syntst
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall msc_arytst_int(^m(tempstr1.arry,arg1Handle))
+            xcall msc_arytst_int(^marray(tempstr1.arry,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT p1 [*]I4)
@@ -3317,7 +3317,7 @@ namespace TraditionalBridge.Test.syntst
 
             ;;Temp structure tempstr1
             structure tempstr1
-                arry, [1]A20
+                arry, A20
             endstructure
 
 
@@ -3339,7 +3339,7 @@ namespace TraditionalBridge.Test.syntst
             ;;------------------------------------------------------------
             ;; Call the underlying routine
 
-            xcall msc_arytst_str(^m(tempstr1.arry,arg1Handle))
+            xcall msc_arytst_str(^marray(tempstr1.arry,arg1Handle))
 
             ;;--------------------------------------------------------------------------------
             ;;Argument 1 (REQUIRED INOUT p1 [*]A20)

--- a/TraditionalBridge.UnitTest/TBTest/Tests/BinaryTransfer.dbl
+++ b/TraditionalBridge.UnitTest/TBTest/Tests/BinaryTransfer.dbl
@@ -94,7 +94,6 @@ namespace TraditionalBridge.UnitTest
         endmethod
 
         {TestCategory("BinaryTransfer")}
-        ;{Ignore("dbr.exe crashes by ntdll.dll here")}
         {TestMethod}
         ;;; <summary>
         ;;; Outs a structure array

--- a/TraditionalBridge.UnitTest/TBTest/Tests/Encrypt.dbl
+++ b/TraditionalBridge.UnitTest/TBTest/Tests/Encrypt.dbl
@@ -104,7 +104,7 @@ namespace TraditionalBridge.UnitTest
             record
                 dispatchResult, @string
         proc
-            dispatchResult = DispatchRunner.RemoveMessageHeader(DispatchRunner.RunDispatchEncrypt('{"jsonrpc":"2.0","id":24,"method":"encrypt_tst4","params":[{"ReturnedValue":false},{"PassedValue":"hello","DataType":1},{"PassedValue":1234,"DataType":8},{"PassedValue":"54321","DataType":2},{"PassedValue":"bye","DataType":1},{"PassedValue":"654.321","DataType":4},{"PassedValue":[""],"DataType":1024},{"PassedValue":[""],"DataType":1024},{"PassedValue":[""],"DataType":1024},{"PassedValue":[""],"DataType":1024}]}'))
+            dispatchResult = DispatchRunner.RemoveMessageHeader(DispatchRunner.RunDispatchEncrypt('{"jsonrpc":"2.0","id":24,"method":"encrypt_tst4","params":[{"ReturnedValue":false},{"PassedValue":"hello","DataType":1},{"PassedValue":1234,"DataType":8},{"PassedValue":"54321","DataType":2},{"PassedValue":"bye","DataType":1},{"PassedValue":"654.321","DataType":4},{"PassedValue":[1,2,3,4,5],"DataType":1024},{"PassedValue":["a","b","c","d","e","f"],"DataType":1024},{"PassedValue":[1.1,2.2,3.3,4.4],"DataType":1024},{"PassedValue":[5,4,3,2,1],"DataType":1024}]}'))
             DispatchRunner.EnsureSuccess(dispatchResult)
         endmethod
         

--- a/TraditionalBridge.UnitTest/TBTest/Tests/Encrypt.dbl
+++ b/TraditionalBridge.UnitTest/TBTest/Tests/Encrypt.dbl
@@ -94,7 +94,6 @@ namespace TraditionalBridge.UnitTest
         endmethod
         
         {TestCategory("Encrypt")}
-        ;{Ignore("dbr.exe crashes by ntdll.dll here")}
         {TestMethod}
         ;;; <summary>
         ;;; Sets properties

--- a/TraditionalBridge.UnitTest/TBTest/Tests/smc.dbl
+++ b/TraditionalBridge.UnitTest/TBTest/Tests/smc.dbl
@@ -62,7 +62,6 @@ namespace TraditionalBridge.UnitTest
         endmethod
         
         {TestCategory("smc")}
-        ;{Ignore("dbr.exe crashes by ntdll.dll here")}
         {TestMethod}
         ;;; <summary>
         ;;; Sets variables passed in

--- a/TraditionalBridge.UnitTest/TBTest/Tests/smc.dbl
+++ b/TraditionalBridge.UnitTest/TBTest/Tests/smc.dbl
@@ -72,7 +72,7 @@ namespace TraditionalBridge.UnitTest
             record
                 dispatchResult, @string
         proc
-            dispatchResult = DispatchRunner.RemoveMessageHeader(DispatchRunner.RunDispatchsmc('{"jsonrpc":"2.0","id":113,"method":"function_eight","params":[{"ReturnedValue":false},{"PassedValue":"hello","DataType":1},{"PassedValue":2012,"DataType":8},{"PassedValue":"201202","DataType":2},{"PassedValue":"world","DataType":1},{"PassedValue":"12345.432","DataType":4},{"PassedValue":["1234","4321"],"DataType":1024},{"PassedValue":["hello","world"],"DataType":1024},{"PassedValue":["2012.02","22.12"],"DataType":1024},{"PassedValue":[2012,222],"DataType":1024}]}'))
+            dispatchResult = DispatchRunner.RemoveMessageHeader(DispatchRunner.RunDispatchsmc('{"jsonrpc":"2.0","id":113,"method":"function_eight","params":[{"ReturnedValue":false},{"PassedValue":"hello","DataType":1},{"PassedValue":2012,"DataType":8},{"PassedValue":"201202","DataType":2},{"PassedValue":"world","DataType":1},{"PassedValue":"12345.432","DataType":4},{"PassedValue":[1,3,5,7,9],"DataType":1024},{"PassedValue":["hello","world","goodbye","moon","sayonara","obrigato"],"DataType":1024},{"PassedValue":[1.2,3.4,5.6,7.8],"DataType":1024},{"PassedValue":[2,4,6,8,10],"DataType":1024}]}'))
             DispatchRunner.EnsureSuccess(dispatchResult)
         endmethod
         

--- a/TraditionalBridge.UnitTest/TBTest/Tests/syntst.dbl
+++ b/TraditionalBridge.UnitTest/TBTest/Tests/syntst.dbl
@@ -481,7 +481,6 @@ namespace TraditionalBridge.UnitTest
         endmethod
         
         {TestCategory("syntst")}
-        ;{Ignore("dbr.exe crashes by ntdll.dll here")}
         {TestMethod}
         ;;; <summary>
         ;;; Sets members of array to decimals
@@ -496,7 +495,6 @@ namespace TraditionalBridge.UnitTest
         endmethod
         
         {TestCategory("syntst")}
-        ;{Ignore("dbr.exe crashes by ntdll.dll here")}
         {TestMethod}
         ;;; <summary>
         ;;; Sets members of array to implied decimals
@@ -511,7 +509,6 @@ namespace TraditionalBridge.UnitTest
         endmethod
         
         {TestCategory("syntst")}
-        ;{Ignore("dbr.exe crashes by ntdll.dll here")}
         {TestMethod}
         ;;; <summary>
         ;;; Sets members of array to ints
@@ -526,7 +523,6 @@ namespace TraditionalBridge.UnitTest
         endmethod
         
         {TestCategory("syntst")}
-        ;{Ignore("dbr.exe crashes by ntdll.dll here")}
         {TestMethod}
         ;;; <summary>
         ;;; Sets members of array to strings

--- a/TraditionalBridge.UnitTest/TBTest/Tests/syntst.dbl
+++ b/TraditionalBridge.UnitTest/TBTest/Tests/syntst.dbl
@@ -491,7 +491,7 @@ namespace TraditionalBridge.UnitTest
             record
                 dispatchResult, @string
         proc
-            dispatchResult = DispatchRunner.RemoveMessageHeader(DispatchRunner.RunDispatchsyntst('{"jsonrpc":"2.0","id":150,"method":"msc_arytst_dec","params":[{"ReturnedValue":false},{"PassedValue":[{"GRFA": "", "Value":""}],"DataType":32}]}'))
+            dispatchResult = DispatchRunner.RemoveMessageHeader(DispatchRunner.RunDispatchsyntst('{"jsonrpc":"2.0","id":150,"method":"msc_arytst_dec","params":[{"ReturnedValue":false},{"PassedValue":[11111,22222,33333,44444,55555],"DataType":1024}]}'))
             DispatchRunner.EnsureSuccess(dispatchResult)
         endmethod
         
@@ -506,7 +506,7 @@ namespace TraditionalBridge.UnitTest
             record
                 dispatchResult, @string
         proc
-            dispatchResult = DispatchRunner.RemoveMessageHeader(DispatchRunner.RunDispatchsyntst('{"jsonrpc":"2.0","id":151,"method":"msc_arytst_imp","params":[{"ReturnedValue":false},{"PassedValue":["1234.567"],"DataType":1024}]}'))
+            dispatchResult = DispatchRunner.RemoveMessageHeader(DispatchRunner.RunDispatchsyntst('{"jsonrpc":"2.0","id":151,"method":"msc_arytst_imp","params":[{"ReturnedValue":false},{"PassedValue":[111.111,222.222,333.333,444.444,555.555],"DataType":1024}]}'))
             DispatchRunner.EnsureSuccess(dispatchResult)
         endmethod
         
@@ -521,7 +521,7 @@ namespace TraditionalBridge.UnitTest
             record
                 dispatchResult, @string
         proc
-            dispatchResult = DispatchRunner.RemoveMessageHeader(DispatchRunner.RunDispatchsyntst('{"jsonrpc":"2.0","id":152,"method":"msc_arytst_int","params":[{"ReturnedValue":false},{"PassedValue":[1234],"DataType":1024}]}'))
+            dispatchResult = DispatchRunner.RemoveMessageHeader(DispatchRunner.RunDispatchsyntst('{"jsonrpc":"2.0","id":152,"method":"msc_arytst_int","params":[{"ReturnedValue":false},{"PassedValue":[2,44,6,88,10],"DataType":1024}]}'))
             DispatchRunner.EnsureSuccess(dispatchResult)
         endmethod
         
@@ -536,7 +536,7 @@ namespace TraditionalBridge.UnitTest
             record
                 dispatchResult, @string
         proc
-            dispatchResult = DispatchRunner.RemoveMessageHeader(DispatchRunner.RunDispatchsyntst('{"jsonrpc":"2.0","id":153,"method":"msc_arytst_str","params":[{"ReturnedValue":false},{"PassedValue":["hello","world"],"DataType":1024}]}'))
+            dispatchResult = DispatchRunner.RemoveMessageHeader(DispatchRunner.RunDispatchsyntst('{"jsonrpc":"2.0","id":153,"method":"msc_arytst_str","params":[{"ReturnedValue":false},{"PassedValue":["hello","world","how","are","you"],"DataType":1024}]}'))
             DispatchRunner.EnsureSuccess(dispatchResult)
         endmethod
         


### PR DESCRIPTION
Fixes #209

None of these unit tests crash anymore due to fixes to arrays for the unit tests.

* Use `^marray` instead of `^m`
* Modified some tests to pass in good length arrays