### PR TITLE
Added messages moving through certain pieces of logic in ArgumentImpl

### DIFF
--- a/HarmonyCore.Test/Bridge/BasicBridge.dbl
+++ b/HarmonyCore.Test/Bridge/BasicBridge.dbl
@@ -21,46 +21,46 @@ namespace HarmonyCore.Test.Bridge
 
         private method GetContextPool<T(IContextBase, class)>, @ExternalContextPool<T>
         proc
-			data currentDirectory = Path.GetDirectoryName(^typeof(BasicBridge).Assembly.Location)
+            data currentDirectory = Path.GetDirectoryName(^typeof(BasicBridge).Assembly.Location)
             data testDirFolder = TestEnvironment.findRelativeFolderForAssembly("TestDir")
             data contextPool = new ExternalContextPool<T>(Environment.GetEnvironmentVariable("SYNERGYDE64") + "dbl\bin\dbs.exe", 'TraditionalBridge.Test.dbr', testDirFolder, ^null, 4) 
             mreturn contextPool
         endmethod
 
-		{TestMethod}
-		public async method InitFailure, @Task
-		proc
-			data currentDirectory = Path.GetDirectoryName(^typeof(BasicBridge).Assembly.Location)
-			data testDirFolder = TestEnvironment.findRelativeFolderForAssembly("TestDir")
-			data contextPool1 = new ExternalContextPool<BasicBridge.ExternalCallContext>(Environment.GetEnvironmentVariable("SYNERGYDE64") + "dbl\bin\dbs.exe", 'TraditionalBridge.Testt.dbr', testDirFolder, ^null, 4) 
-			data sp = new ServiceCollection().BuildServiceProvider()
-			try
-			begin
-				data context = contextPool1.MakeContext(sp)
-				await context.GetAllCustomers()
+        {TestMethod}
+        public async method InitFailure, @Task
+        proc
+            data currentDirectory = Path.GetDirectoryName(^typeof(BasicBridge).Assembly.Location)
+            data testDirFolder = TestEnvironment.findRelativeFolderForAssembly("TestDir")
+            data contextPool1 = new ExternalContextPool<BasicBridge.ExternalCallContext>(Environment.GetEnvironmentVariable("SYNERGYDE64") + "dbl\bin\dbs.exe", 'TraditionalBridge.Testt.dbr', testDirFolder, ^null, 4) 
+            data sp = new ServiceCollection().BuildServiceProvider()
+            try
+            begin
+                data context = contextPool1.MakeContext(sp)
+                await context.GetAllCustomers()
                 Assert.Fail()
-			end
-			catch(ex, @BridgeConnectionException)
-			begin
+            end
+            catch(ex, @BridgeConnectionException)
+            begin
                 Assert.AreEqual(ex.InnerMessage, "TraditionalBridge failed to initialize most likely due to missing dbr or elb file.")
-			end
+            end
             endtry
 
 
-			data contextPool2 = new ExternalContextPool<BasicBridge.ExternalCallContext>(Environment.GetEnvironmentVariable("SYNERGYDE32") + "dbl\bin\dbs.exe", 'TraditionalBridge.Test.dbr', testDirFolder, ^null, 4) 
+            data contextPool2 = new ExternalContextPool<BasicBridge.ExternalCallContext>(Environment.GetEnvironmentVariable("SYNERGYDE32") + "dbl\bin\dbs.exe", 'TraditionalBridge.Test.dbr', testDirFolder, ^null, 4) 
 
-			try
-			begin
-				data context = contextPool2.MakeContext(sp)
-				await context.GetAllCustomers()
-				Assert.Fail()
-			end
-			catch(ex, @BridgeConnectionException)
-			begin
-				Assert.AreEqual(ex.InnerMessage, "TraditionalBridge failed to initialize most likely due to x86/x64 mismatch.")
-			end
-			endtry
-		endmethod
+            try
+            begin
+                data context = contextPool2.MakeContext(sp)
+                await context.GetAllCustomers()
+                Assert.Fail()
+            end
+            catch(ex, @BridgeConnectionException)
+            begin
+                Assert.AreEqual(ex.InnerMessage, "TraditionalBridge failed to initialize most likely due to x86/x64 mismatch.")
+            end
+            endtry
+        endmethod
 
 
         {TestMethod}
@@ -71,12 +71,12 @@ namespace HarmonyCore.Test.Bridge
             
             data context = contextPool.MakeContext(sp)
             
-			Console.WriteLine("Calling GetAllCustomers")
+            Console.WriteLine("Calling GetAllCustomers")
             data customers = await context.GetAllCustomers()
             
             try
-			begin
-				Console.WriteLine("Calling Exception Test")
+            begin
+                Console.WriteLine("Calling Exception Test")
                 data failureResult = await context.Arbitrario_Exception()
                 Assert.Fail("exception wasnt thrown")
             end
@@ -92,20 +92,20 @@ namespace HarmonyCore.Test.Bridge
             endtry
 
             try
-			begin
-				Console.WriteLine("Calling Stop Test")
+            begin
+                Console.WriteLine("Calling Stop Test")
                 data failureResult = await context.Arbitrario_Stop()
                 Assert.Fail("exception wasnt thrown")
             end
             catch(ex, @Exception)
             begin
-				contextPool.ReturnContext(context)
+                contextPool.ReturnContext(context)
                 context = contextPool.MakeContext(sp)
             end
 
             endtry
 
-			Console.WriteLine("Calling Parameter tests")
+            Console.WriteLine("Calling Parameter tests")
             data arbitrarioReturn = await context.Arbitrario_MethodWithParameters()
             data functionFourReturn = await context.function_four("hello", "some", "text", "here")
 
@@ -119,10 +119,10 @@ namespace HarmonyCore.Test.Bridge
             Assert.AreEqual(arbitrarioReturn.IntList.Count, 1, "arbitrario int array count was wrong")
             Assert.AreEqual(arbitrarioReturn.StringList.Count, 3, "arbitrario string array count was wrong")
 
-			Console.WriteLine("Calling Structure test")
+            Console.WriteLine("Calling Structure test")
             data structuresReturn = await context.Arbitrario_Structures()
 
-			contextPool.ReturnContext(context)
+            contextPool.ReturnContext(context)
             Console.WriteLine("Trimming Pool")
             await contextPool.TrimPool(0)
             Console.WriteLine("shutting down test")

--- a/HarmonyCore.Test/Bridge/BasicBridge.dbl
+++ b/HarmonyCore.Test/Bridge/BasicBridge.dbl
@@ -294,6 +294,44 @@ namespace HarmonyCore.Test.Bridge
             ArgumentHelper.Argument<List<Boolean>>(0, new Tuple<Object, [#]Object>(7, new List<Object>().ToArray()), outval)
         endmethod
 
+        {TestMethod}
+        public method MaybeTests, void
+        proc
+            Assert.AreEqual(0, ArgumentHelper.MaybeNull(new Nullable<int>(0)))
+            Assert.AreEqual((long)0, ArgumentHelper.MaybeNull(new Nullable<long>(0)))
+            Assert.AreEqual((short)0, ArgumentHelper.MaybeNull(new Nullable<short>(0)))
+            Assert.AreEqual((byte)0, ArgumentHelper.MaybeNull(new Nullable<byte>(0)))
+            Assert.AreEqual((single)0, ArgumentHelper.MaybeNull(new Nullable<single>(0)))
+            Assert.AreEqual((double)0, ArgumentHelper.MaybeNull(new Nullable<double>(0)))
+            Assert.AreEqual((decimal)0, ArgumentHelper.MaybeNull(new Nullable<decimal>(0)))
+
+            ; AMBSYM error here
+;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<int>()))
+;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<long>()))
+;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<short>()))
+;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<byte>()))
+;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<single>()))
+;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<double>()))
+;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<decimal>()))
+
+            Assert.AreEqual(0, ArgumentHelper.MaybeOptional(new Nullable<int>(0)))
+            Assert.AreEqual((long)0, ArgumentHelper.MaybeOptional(new Nullable<long>(0)))
+            Assert.AreEqual((short)0, ArgumentHelper.MaybeOptional(new Nullable<short>(0)))
+            Assert.AreEqual((byte)0, ArgumentHelper.MaybeOptional(new Nullable<byte>(0)))
+            Assert.AreEqual((single)0, ArgumentHelper.MaybeOptional(new Nullable<single>(0)))
+            Assert.AreEqual((double)0, ArgumentHelper.MaybeOptional(new Nullable<double>(0)))
+            Assert.AreEqual((decimal)0, ArgumentHelper.MaybeOptional(new Nullable<decimal>(0)))
+
+            ; AMBSYM error here
+;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<int>()))
+;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<long>()))
+;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<short>()))
+;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<byte>()))
+;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<single>()))
+;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<double>()))
+;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<decimal>()))
+        endmethod
+
         public class ExternalCallContext extends DynamicCallProvider
             public method ExternalCallContext
                 connection, @IDynamicCallConnection

--- a/HarmonyCore.Test/Bridge/BasicBridge.dbl
+++ b/HarmonyCore.Test/Bridge/BasicBridge.dbl
@@ -248,6 +248,27 @@ namespace HarmonyCore.Test.Bridge
             await contextPool.TrimPool(0)
             Console.WriteLine("shutting down test {0}", timeTaken)
         endmethod
+        
+        {TestMethod}
+        public method ArgumentHelperArgumentBadCast, void
+        proc
+            data return = ArgumentHelper.Argument<Boolean>(0, new Tuple<Object, [#]Object>(7, new List<Object>().ToArray()))
+            Assert.IsTrue(return)
+        endmethod
+
+        {TestMethod}
+        public method ArgumentHelperArgumentNull, void
+        proc
+            data return = ArgumentHelper.Argument<List<Boolean>>(0, new Tuple<Object, [#]Object>(^null, new List<Object>().ToArray()))
+            Assert.IsNull(return)
+        endmethod
+
+        {TestMethod}
+        {ExpectedException(^typeof(Exception))}
+        public method ArgumentHelperArgumentExceptionCast, void
+        proc
+            data return = ArgumentHelper.Argument<List<Boolean>>(0, new Tuple<Object, [#]Object>(7, new List<Object>().ToArray()))
+        endmethod
 
         public class ExternalCallContext extends DynamicCallProvider
             public method ExternalCallContext

--- a/HarmonyCore.Test/Bridge/BasicBridge.dbl
+++ b/HarmonyCore.Test/Bridge/BasicBridge.dbl
@@ -255,6 +255,14 @@ namespace HarmonyCore.Test.Bridge
             data return = ArgumentHelper.Argument<Boolean>(0, new Tuple<Object, [#]Object>(7, new List<Object>().ToArray()))
             Assert.IsTrue(return)
         endmethod
+        
+        {TestMethod}
+        public method ArgumentHelperArgumentBadCast2, void
+        proc
+            data outval, boolean
+            ArgumentHelper.Argument<Boolean>(0, new Tuple<Object, [#]Object>(7, new List<Object>().ToArray()), outval)
+            Assert.IsTrue(outval)
+        endmethod
 
         {TestMethod}
         public method ArgumentHelperArgumentNull, void
@@ -264,10 +272,26 @@ namespace HarmonyCore.Test.Bridge
         endmethod
 
         {TestMethod}
+        public method ArgumentHelperArgumentNull2, void
+        proc
+            data outval, @List<Boolean>
+            ArgumentHelper.Argument<List<Boolean>>(0, new Tuple<Object, [#]Object>(^null, new List<Object>().ToArray()), outval)
+            Assert.IsNull(outval)
+        endmethod
+
+        {TestMethod}
         {ExpectedException(^typeof(Exception))}
         public method ArgumentHelperArgumentExceptionCast, void
         proc
             data return = ArgumentHelper.Argument<List<Boolean>>(0, new Tuple<Object, [#]Object>(7, new List<Object>().ToArray()))
+        endmethod
+
+        {TestMethod}
+        {ExpectedException(^typeof(Exception))}
+        public method ArgumentHelperArgumentExceptionCast2, void
+        proc
+            data outval, @List<Boolean>
+            ArgumentHelper.Argument<List<Boolean>>(0, new Tuple<Object, [#]Object>(7, new List<Object>().ToArray()), outval)
         endmethod
 
         public class ExternalCallContext extends DynamicCallProvider

--- a/HarmonyCore.Test/Bridge/BasicBridge.dbl
+++ b/HarmonyCore.Test/Bridge/BasicBridge.dbl
@@ -306,13 +306,21 @@ namespace HarmonyCore.Test.Bridge
             Assert.AreEqual((decimal)0, ArgumentHelper.MaybeNull(new Nullable<decimal>(0)))
 
             ; AMBSYM error here
-;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<int>()))
-;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<long>()))
-;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<short>()))
-;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<byte>()))
-;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<single>()))
-;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<double>()))
-;            Assert.IsNotNull(ArgumentHelper.MaybeNull(new Nullable<decimal>()))
+            data nullint, Nullable<int>
+            data nulllong, Nullable<long>
+            data nullshort, Nullable<short>
+            data nullbyte, Nullable<byte>
+            data nullsingle, Nullable<single>
+            data nulldouble, Nullable<double>
+            data nulldecimal, Nullable<decimal>
+
+            Assert.IsNotNull(ArgumentHelper.MaybeNull(nullint))
+            Assert.IsNotNull(ArgumentHelper.MaybeNull(nulllong))
+            Assert.IsNotNull(ArgumentHelper.MaybeNull(nullshort))
+            Assert.IsNotNull(ArgumentHelper.MaybeNull(nullbyte))
+            Assert.IsNotNull(ArgumentHelper.MaybeNull(nullsingle))
+            Assert.IsNotNull(ArgumentHelper.MaybeNull(nulldouble))
+            Assert.IsNotNull(ArgumentHelper.MaybeNull(nulldecimal))
 
             Assert.AreEqual(0, ArgumentHelper.MaybeOptional(new Nullable<int>(0)))
             Assert.AreEqual((long)0, ArgumentHelper.MaybeOptional(new Nullable<long>(0)))
@@ -322,14 +330,13 @@ namespace HarmonyCore.Test.Bridge
             Assert.AreEqual((double)0, ArgumentHelper.MaybeOptional(new Nullable<double>(0)))
             Assert.AreEqual((decimal)0, ArgumentHelper.MaybeOptional(new Nullable<decimal>(0)))
 
-            ; AMBSYM error here
-;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<int>()))
-;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<long>()))
-;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<short>()))
-;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<byte>()))
-;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<single>()))
-;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<double>()))
-;            Assert.IsNotNull(ArgumentHelper.MaybeOptional(new Nullable<decimal>()))
+            Assert.IsNotNull(ArgumentHelper.MaybeOptional(nullint))
+            Assert.IsNotNull(ArgumentHelper.MaybeOptional(nulllong))
+            Assert.IsNotNull(ArgumentHelper.MaybeOptional(nullshort))
+            Assert.IsNotNull(ArgumentHelper.MaybeOptional(nullbyte))
+            Assert.IsNotNull(ArgumentHelper.MaybeOptional(nullsingle))
+            Assert.IsNotNull(ArgumentHelper.MaybeOptional(nulldouble))
+            Assert.IsNotNull(ArgumentHelper.MaybeOptional(nulldecimal))
         endmethod
 
         public class ExternalCallContext extends DynamicCallProvider

--- a/HarmonyCore/ArgumentDataDefinition.dbl
+++ b/HarmonyCore/ArgumentDataDefinition.dbl
@@ -274,8 +274,12 @@ namespace Harmony.Core
 		proc
 			data tVal, T
 
-			if(arg == ^null)
+            ;; Null arg is passed in. Will return to default value of T
+            if(arg == ^null)
+            begin
+                Console.WriteLine("Warning: Null was passed into Argument/ArgumentInfer. Default value of {0} will be returned.", ^typeof(T).UnderlyingSystemType.Name)
 				mreturn tVal
+            end
 
 			data argType = arg.GetType()
 
@@ -324,12 +328,13 @@ namespace Harmony.Core
 			end
 			else
 				try
-				begin
+                begin
+                    Console.WriteLine("Converting {0} to {1}.", arg, ^typeof(T).UnderlyingSystemType.Name)
 					mreturn (T)Convert.ChangeType(arg, ^typeof(T))
 				end
 				catch(ex, @Exception)
-				begin
-					throw new NotImplementedException(string.Format("{0} not a currently supported type in Traditional Bridge", ^typeof(T)))
+                begin
+                    throw new Exception(string.Format("{0}{1}There was a mismatch trying to convert {2} to {3}.", ex.Message, Environment.NewLine, arg, ^typeof(T).UnderlyingSystemType.Name))
 				end
 				endtry
 

--- a/HarmonyCore/ArgumentDataDefinition.dbl
+++ b/HarmonyCore/ArgumentDataDefinition.dbl
@@ -274,12 +274,12 @@ namespace Harmony.Core
 		proc
 			data tVal, T
 
-            ;; Null arg is passed in. Will return to default value of T
-            if(arg == ^null)
-            begin
-                Console.WriteLine("Warning: Null was passed into Argument/ArgumentInfer. Default value of {0} will be returned.", ^typeof(T).UnderlyingSystemType.Name)
+			;; Null arg is passed in. Will return to default value of T
+			if(arg == ^null)
+			begin
+				Console.WriteLine("Warning: Null was passed into Argument/ArgumentInfer. Default value of {0} will be returned.", ^typeof(T).UnderlyingSystemType.Name)
 				mreturn tVal
-            end
+			end
 
 			data argType = arg.GetType()
 
@@ -328,13 +328,13 @@ namespace Harmony.Core
 			end
 			else
 				try
-                begin
-                    Console.WriteLine("Converting {0} to {1}.", arg, ^typeof(T).UnderlyingSystemType.Name)
+				begin
+					Console.WriteLine("Converting {0} to {1}.", arg, ^typeof(T).UnderlyingSystemType.Name)
 					mreturn (T)Convert.ChangeType(arg, ^typeof(T))
 				end
 				catch(ex, @Exception)
-                begin
-                    throw new Exception(string.Format("{0}{1}There was a mismatch trying to convert {2} to {3}.", ex.Message, Environment.NewLine, arg, ^typeof(T).UnderlyingSystemType.Name))
+				begin
+					throw new Exception(string.Format("{0}{1}There was a mismatch trying to convert {2} to {3}.", ex.Message, Environment.NewLine, arg, ^typeof(T).UnderlyingSystemType.Name))
 				end
 				endtry
 


### PR DESCRIPTION
Fixes #192 by providing feedback with certain flow through `ArgumentImpl` could result in an ambiguous result:
* Passing in null results in default
* Conversion of argument to a type could result in unexpected result or exception