### PR TITLE
Compatibility with upcoming SDI .NET Core UT support

### DIFF
--- a/HarmonyCore.Test/HarmonyCore.Test.synproj
+++ b/HarmonyCore.Test/HarmonyCore.Test.synproj
@@ -12,6 +12,7 @@
     <RuntimeIdentifiers>linux-x64;win7-x64</RuntimeIdentifiers>
     <EnableCommonProperties>True</EnableCommonProperties>
     <CommonPropertiesFileLocation>$(SolutionDir)Common.props</CommonPropertiesFileLocation>
+    <ProvidesMainMethod>true</ProvidesMainMethod>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Bridge\BasicBridge.dbl" />

--- a/TraditionalBridge.TestClient/TraditionalBridge.TestClient.synproj
+++ b/TraditionalBridge.TestClient/TraditionalBridge.TestClient.synproj
@@ -11,6 +11,7 @@
     <EnableCommonProperties>True</EnableCommonProperties>
     <CommonPropertiesFileLocation>$(SolutionDir)Common.props</CommonPropertiesFileLocation>
     <IncludeDebugInformation>False</IncludeDebugInformation>
+    <ProvidesMainMethod>true</ProvidesMainMethod>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath />


### PR DESCRIPTION
The SDI product is getting .NET Core unit test support. One of the mechanisms that comes along with that support is automatic generation of "main" methods, as required by the Microsoft Test SDK. Since HarmonyCore already has mainlines in its test projects, we have added a property to disable the automatic mainline generation.

This PR adds that property to HarmonyCore's test projects so that you will have no impact when taking the Synergex.SynergyDE.Build package update.

In the interim, this change will have no impact on the functionality of HarmonyCore.