### PR TITLE
Replaced all <FIELD_DESC> tokens with <FIELD_DESC_DOUBLE> to guard ag…

### DIFF
--- a/Templates/ODataClientModel.tpl
+++ b/Templates/ODataClientModel.tpl
@@ -1,5 +1,5 @@
 <CODEGEN_FILENAME><StructureNoplural>.dbl</CODEGEN_FILENAME>
-<REQUIRES_CODEGEN_VERSION>5.4.6</REQUIRES_CODEGEN_VERSION>
+<REQUIRES_CODEGEN_VERSION>5.7.5</REQUIRES_CODEGEN_VERSION>
 <REQUIRES_OPTION>TF</REQUIRES_OPTION>
 <CODEGEN_FOLDER>Models</CODEGEN_FOLDER>
 ;//****************************************************************************
@@ -58,7 +58,7 @@ namespace <NAMESPACE>
 <FIELD_LOOP>
   <IF CUSTOM_NOT_HARMONY_EXCLUDE>
         ;;; <summary>
-        ;;; <FIELD_DESC>
+        ;;; <FIELD_DESC_DOUBLE>
         ;;; </summary>
     <IF CUSTOM_HARMONY_AS_STRING>
         public readwrite property <FieldSqlname>, String

--- a/Templates/ODataController.tpl
+++ b/Templates/ODataController.tpl
@@ -154,7 +154,7 @@ namespace <NAMESPACE>
   <PRIMARY_KEY>
     <SEGMENT_LOOP>
       <IF NOT SEG_TAG_EQUAL>
-        ;;; <param name="a<FieldSqlName>"><FIELD_DESC></param>
+        ;;; <param name="a<FieldSqlName>"><FIELD_DESC_DOUBLE></param>
       </IF>
     </SEGMENT_LOOP>
   </PRIMARY_KEY>
@@ -198,7 +198,7 @@ namespace <NAMESPACE>
   <PRIMARY_KEY>
     <SEGMENT_LOOP>
       <IF NOT SEG_TAG_EQUAL>
-        ;;; <param name="a<FieldSqlName>"><FIELD_DESC></param>
+        ;;; <param name="a<FieldSqlName>"><FIELD_DESC_DOUBLE></param>
       </IF>
     </SEGMENT_LOOP>
   </PRIMARY_KEY>
@@ -280,7 +280,7 @@ namespace <NAMESPACE>
         ;;; </summary>
       <SEGMENT_LOOP>
         <IF NOT SEG_TAG_EQUAL>
-        ;;; <param name="a<FieldSqlName>"><FIELD_DESC></param>
+        ;;; <param name="a<FieldSqlName>"><FIELD_DESC_DOUBLE></param>
         </IF>
       </SEGMENT_LOOP>
         ;;; <returns>Returns an IActionResult indicating the status of the operation and containing any data that was returned.</returns>
@@ -327,7 +327,7 @@ namespace <NAMESPACE>
         ;;; </summary>
       <SEGMENT_LOOP>
         <IF NOT SEG_TAG_EQUAL>
-        ;;; <param name="a<FieldSqlName>"><FIELD_DESC></param>
+        ;;; <param name="a<FieldSqlName>"><FIELD_DESC_DOUBLE></param>
         </IF>
       </SEGMENT_LOOP>
         ;;; <returns>Returns an IActionResult indicating the status of the operation and containing any data that was returned.</returns>
@@ -431,7 +431,7 @@ namespace <NAMESPACE>
         ;;; </summary>
       <SEGMENT_LOOP>
         <IF NOT SEG_TAG_EQUAL>
-        ;;; <param name="a<FieldSqlName>"><FIELD_DESC></param>
+        ;;; <param name="a<FieldSqlName>"><FIELD_DESC_DOUBLE></param>
         </IF>
       </SEGMENT_LOOP>
         ;;; <returns>Returns an IActionResult indicating the status of the operation and containing any data that was returned.</returns>
@@ -526,7 +526,7 @@ namespace <NAMESPACE>
         ;;; </summary>
         <SEGMENT_LOOP>
           <IF NOT SEG_TAG_EQUAL>
-        ;;; <param name="a<FieldSqlName>"><FIELD_DESC></param>
+        ;;; <param name="a<FieldSqlName>"><FIELD_DESC_DOUBLE></param>
           </IF>
         </SEGMENT_LOOP>
         ;;; <returns>Returns an IActionResult indicating the status of the operation and containing any data that was returned.</returns>
@@ -614,7 +614,7 @@ namespace <NAMESPACE>
         ;;; </summary>
         <SEGMENT_LOOP>
           <IF NOT SEG_TAG_EQUAL>
-        ;;; <param name="a<FieldSqlName>"><FIELD_DESC></param>
+        ;;; <param name="a<FieldSqlName>"><FIELD_DESC_DOUBLE></param>
           </IF>
         </SEGMENT_LOOP>
         ;;; <returns>Returns an IActionResult indicating the status of the operation and containing any data that was returned.</returns>

--- a/Templates/ODataControllerPropertyEndpoints.tpl
+++ b/Templates/ODataControllerPropertyEndpoints.tpl
@@ -1,5 +1,5 @@
 <CODEGEN_FILENAME><StructurePlural>ControllerPropertyEndpoints.dbl</CODEGEN_FILENAME>
-<REQUIRES_CODEGEN_VERSION>5.5.2</REQUIRES_CODEGEN_VERSION>
+<REQUIRES_CODEGEN_VERSION>5.7.5</REQUIRES_CODEGEN_VERSION>
 ;//****************************************************************************
 ;//
 ;// Title:       ODataControllerPropertyEndpoints.tpl
@@ -80,11 +80,11 @@ namespace <NAMESPACE>
         ;;; Get the <FieldSqlName> property of a single <StructureNoplural>, by primary key.
         ;;; </summary>
             <IF SINGLE_SEGMENT>
-        ;;; <param name="key"><FIELD_DESC></param>
+        ;;; <param name="key"><FIELD_DESC_DOUBLE></param>
             <ELSE>
               <SEGMENT_LOOP>
                 <IF NOT SEG_TAG_EQUAL>
-        ;;; <param name="a<FieldSqlName>"><FIELD_DESC></param>
+        ;;; <param name="a<FieldSqlName>"><FIELD_DESC_DOUBLE></param>
                 </IF SEG_TAG_EQUAL>
               </SEGMENT_LOOP>
             </IF SINGLE_SEGMENT>

--- a/Templates/ODataModel.tpl
+++ b/Templates/ODataModel.tpl
@@ -117,7 +117,7 @@ namespace <NAMESPACE>
 <FIELD_LOOP>
     <IF CUSTOM_NOT_HARMONY_EXCLUDE>
         ;;; <summary>
-        ;;; <FIELD_DESC>
+        ;;; <FIELD_DESC_DOUBLE>
         ;;; </summary>
 ;//
 ;// Field property attributes

--- a/Templates/TraditionalBridge/ODataModel.tpl
+++ b/Templates/TraditionalBridge/ODataModel.tpl
@@ -116,7 +116,7 @@ namespace <NAMESPACE>
 <FIELD_LOOP>
     <IF CUSTOM_NOT_HARMONY_EXCLUDE>
         ;;; <summary>
-        ;;; <FIELD_DESC>
+        ;;; <FIELD_DESC_DOUBLE>
         ;;; </summary>
 ;//
 ;// Field property attributes

--- a/Templates/TraditionalBridge/TraditionalModel.tpl
+++ b/Templates/TraditionalBridge/TraditionalModel.tpl
@@ -1,6 +1,6 @@
 <CODEGEN_FILENAME><StructureNoplural>.dbl</CODEGEN_FILENAME>
 <PROCESS_TEMPLATE>TraditionalModel</PROCESS_TEMPLATE>
-<REQUIRES_CODEGEN_VERSION>5.4.6</REQUIRES_CODEGEN_VERSION>
+<REQUIRES_CODEGEN_VERSION>5.7.5</REQUIRES_CODEGEN_VERSION>
 ;//****************************************************************************
 ;//
 ;// Title:       ODataModel.tpl
@@ -85,7 +85,7 @@ namespace <NAMESPACE>
 		<FIELD_LOOP>
 		<IF CUSTOM_NOT_HARMONY_EXCLUDE>
 		;;; <summary>
-		;;; <FIELD_DESC>
+		;;; <FIELD_DESC_DOUBLE>
 		;;; </summary>
 		public property <FieldSqlname>, <field_type>
 			method get

--- a/TemplatesStandaloneEf/EfProviderModel.tpl
+++ b/TemplatesStandaloneEf/EfProviderModel.tpl
@@ -115,7 +115,7 @@ namespace <NAMESPACE>
   <ELSE>
     <IF CUSTOM_NOT_HARMONY_EXCLUDE>
         ;;; <summary>
-        ;;; <FIELD_DESC>
+        ;;; <FIELD_DESC_DOUBLE>
         ;;; </summary>
 ;//
 ;// Field property attributes


### PR DESCRIPTION
Replaced all \<FIELD_DESC\> tokens with \<FIELD_DESC_DOUBLE\> to guard against double quotes embedded within field descriptions.