### PR TITLE
Fixed message for invalid values of ASPNETCORE_LOG_LEVEL

### DIFF
--- a/Services/Startup.dbl
+++ b/Services/Startup.dbl
@@ -124,11 +124,11 @@ namespace Services
                 ('6 ','none '),
                     log_level = Microsoft.Extensions.Logging.LogLevel.None
                 (),
-                    throw new Exception("Invalid value for logical ODATA_LOG_LEVEL="+logical(1:loglen))
+                    throw new Exception("Invalid value for logical ASPNETCORE_LOG_LEVEL="+logical(1:loglen))
                 endusing
             end
 
-            
+
             lambda configureLogging(builder)
             begin
                 builder.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace)
@@ -271,7 +271,7 @@ namespace Services
                 begin
                     iformatter.SupportedMediaTypes.Add(new MediaTypeHeaderValue(sseg))
                 end
-                
+
                 op.MaxIAsyncEnumerableBufferLimit = int.MaxValue
 
                 ;;If there is a MvcConfigCustom method, call it


### PR DESCRIPTION
Just a fix to the message emitted when a bad value is encountered.