### PR TITLE
Add a property to expose the logger channel.

### DIFF
--- a/TraditionalBridge/Logger.dbl
+++ b/TraditionalBridge/Logger.dbl
@@ -38,6 +38,13 @@ namespace Harmony.TraditionalBridge
             end
         endmethod
 
+        public property LogChannel, int
+            method get
+            proc
+                mreturn (mActiveSettings.OnDiskLogLevel >= 0) ? mLoggingChannel : 0
+            endmethod
+        endproperty
+
         public method LogHnd, void
             handleValue, D_HANDLE
         proc


### PR DESCRIPTION
In implementing code to run in dev and test scenarios to detect when legacy code has inadvertently left channels open, I need to know the channel number in use by the logger, so I know it's OK that channel is open.