### PR TITLE
Remove causing the namespace and values ArrayList to get out of sync

### DIFF
--- a/TraditionalBridge/StringDictionary.dbl
+++ b/TraditionalBridge/StringDictionary.dbl
@@ -132,7 +132,7 @@ namespace Harmony.TraditionalBridge
 				objectAccesCode, i4
 				objectIndex, i4
 		proc
-			if(nspc_find(symbolTableId, key,objectIndex, objectAccesCode) != 0)
+			if((objectAccesCode=%nspc_find(symbolTableId,key,objectIndex)) != 0)
 			begin
 				nspc_delete(symbolTableId, objectAccesCode)
 				RemoveObjectInternal(objectIndex)


### PR DESCRIPTION
Incorrect use of the %nspc_find function was causing incorrect ArrayList indexes to be used when nullifying items in the objectStore ArrayList.