### PR TITLE
Fixed an issue in Swagger docs when authentication is ebabled

### DIFF
--- a/Templates/ODataStartup.tpl
+++ b/Templates/ODataStartup.tpl
@@ -330,7 +330,7 @@ namespace <NAMESPACE>
                 &   "Bearer",
                 &   new OpenApiSecurityScheme() {
                 &       Name = "Authorization",
-                &       Type = SecuritySchemeType.ApiKey,
+                &       Type = SecuritySchemeType.Http,
                 &       Scheme = "Bearer",
                 &       BearerFormat = "JWT",
                 &       In = ParameterLocation.Header,


### PR DESCRIPTION
Switching SecuritySchemeType from ApiKey to Http causes swagger to automatically prefix the JWT with Bearer. Without this it has t be done manually on each call. I have tested this in my current project.